### PR TITLE
Morning Mr. Freeman

### DIFF
--- a/Numix-Circle/48x48/applications/steam_icon_320.svg
+++ b/Numix-Circle/48x48/applications/steam_icon_320.svg
@@ -1,0 +1,1 @@
+steam_icon_220.svg

--- a/Numix-Circle/48x48/applications/steam_icon_340.svg
+++ b/Numix-Circle/48x48/applications/steam_icon_340.svg
@@ -1,0 +1,1 @@
+steam_icon_220.svg

--- a/Numix-Circle/48x48/applications/steam_icon_380.svg
+++ b/Numix-Circle/48x48/applications/steam_icon_380.svg
@@ -1,0 +1,1 @@
+steam_icon_220.svg

--- a/Numix-Circle/48x48/applications/steam_icon_420.svg
+++ b/Numix-Circle/48x48/applications/steam_icon_420.svg
@@ -1,0 +1,1 @@
+steam_icon_220.svg


### PR DESCRIPTION
All the games that follow Half-Life 2 (Episode 1 & 2, Deathmatch and Lost Coast) use the same icon so I thought I'd add symlinks in for them.
