### PR TITLE
libreoffice 4.2 symlinks

### DIFF
--- a/Numix-Circle/48x48/applications/libreoffice4.2-base.svg
+++ b/Numix-Circle/48x48/applications/libreoffice4.2-base.svg
@@ -1,0 +1,1 @@
+libreoffice-base.svg

--- a/Numix-Circle/48x48/applications/libreoffice4.2-calc.svg
+++ b/Numix-Circle/48x48/applications/libreoffice4.2-calc.svg
@@ -1,0 +1,1 @@
+libreoffice-calc.svg

--- a/Numix-Circle/48x48/applications/libreoffice4.2-draw.svg
+++ b/Numix-Circle/48x48/applications/libreoffice4.2-draw.svg
@@ -1,0 +1,1 @@
+libreoffice-draw.svg

--- a/Numix-Circle/48x48/applications/libreoffice4.2-impress.svg
+++ b/Numix-Circle/48x48/applications/libreoffice4.2-impress.svg
@@ -1,0 +1,1 @@
+libreoffice-impress.svg

--- a/Numix-Circle/48x48/applications/libreoffice4.2-math.svg
+++ b/Numix-Circle/48x48/applications/libreoffice4.2-math.svg
@@ -1,0 +1,1 @@
+libreoffice-math.svg

--- a/Numix-Circle/48x48/applications/libreoffice4.2-startcenter
+++ b/Numix-Circle/48x48/applications/libreoffice4.2-startcenter
@@ -1,0 +1,1 @@
+libreoffice-startcenter.svg

--- a/Numix-Circle/48x48/applications/libreoffice4.2-writer.svg
+++ b/Numix-Circle/48x48/applications/libreoffice4.2-writer.svg
@@ -1,0 +1,1 @@
+libreoffice-writer.svg


### PR DESCRIPTION
symlinks for libreoffice 4.2 desktop files (official site packages)

//   -----   //
grep "Icon" /usr/share/applications/libreoffice4.2-*
/usr/share/applications/libreoffice4.2-base.desktop:Icon=libreoffice4.2-base
/usr/share/applications/libreoffice4.2-calc.desktop:Icon=libreoffice4.2-calc
/usr/share/applications/libreoffice4.2-draw.desktop:Icon=libreoffice4.2-draw
/usr/share/applications/libreoffice4.2-impress.desktop:Icon=libreoffice4.2-impress
/usr/share/applications/libreoffice4.2-math.desktop:Icon=libreoffice4.2-math
/usr/share/applications/libreoffice4.2-startcenter.desktop:Icon=libreoffice4.2-startcenter
/usr/share/applications/libreoffice4.2-writer.desktop:Icon=libreoffice4.2-writer
//   -----   //
