### PR TITLE
Latexila own new icon, no symlink.

### DIFF
--- a/Numix-Circle/48x48/apps/latexila.svg
+++ b/Numix-Circle/48x48/apps/latexila.svg
@@ -63,11 +63,11 @@
     <linearGradient
        id="linearGradient3784">
       <stop
-         style="stop-color:#00fa76;stop-opacity:1;"
+         style="stop-color:#00e66d;stop-opacity:1;"
          offset="0"
          id="stop3786" />
       <stop
-         style="stop-color:#00e66c;stop-opacity:1;"
+         style="stop-color:#00d263;stop-opacity:1;"
          offset="1"
          id="stop3788" />
     </linearGradient>


### PR DESCRIPTION
I've made an icon for LaTeXila. There was a symlink to generic TeX editor. 

![icons](https://cloud.githubusercontent.com/assets/8478202/4985700/37693398-6930-11e4-9cd7-c083cb1f57bd.png)

There is an open issue about this: https://github.com/numixproject/numix-icon-theme-circle/issues/1230
