### PR TITLE
Icons for Bygfoot, Aseprite, Lingot, KBibtex and Scorched3D

### DIFF
--- a/Numix-Circle/48x48/apps/aseprite.svg
+++ b/Numix-Circle/48x48/apps/aseprite.svg
@@ -1,0 +1,1456 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 13.546667 13.546667"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="aseprite_.svg">
+  <metadata
+     id="metadata331">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview329"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="31.68978"
+     inkscape:cy="22.209507"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     inkscape:snap-to-guides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3308" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4073">
+      <stop
+         style="stop-color:#b2c1ca;stop-opacity:1;"
+         offset="0"
+         id="stop4075" />
+      <stop
+         style="stop-color:#becbd2;stop-opacity:1;"
+         offset="1"
+         id="stop4077" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4121">
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:1;"
+         offset="0"
+         id="stop4123" />
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:0;"
+         offset="1"
+         id="stop4125" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#3d3d3d;stop-opacity:1;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="0">
+      <stop
+         stop-color="#198ba6"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#42c9e7"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath11">
+      <path
+         d="m 489.217,197.275 c -2.603,0 -3.953,-1.367 -3.953,-3.971 l 0,0 0,-1.034 c 0,-2.604 1.35,-3.971 3.953,-3.971 l 0,0 1.035,0 c 2.62,0 3.97,1.367 3.97,3.971 l 0,0 0,1.034 c 0,2.604 -1.35,3.971 -3.97,3.971 l 0,0 -1.035,0 z"
+         id="path13" />
+    </clipPath>
+    <linearGradient
+       id="1">
+      <stop
+         stop-color="#620000"
+         id="stop16"
+         offset="0"
+         style="stop-color:#f96963;stop-opacity:1;" />
+      <stop
+         offset="1"
+         stop-color="#dd0f0f"
+         id="stop18"
+         style="stop-color:#f96963;stop-opacity:1;" />
+    </linearGradient>
+    <clipPath
+       id="clipPath20">
+      <rect
+         y="223"
+         x="307"
+         height="42"
+         width="42"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#2)"
+         color="#bebebe"
+         rx="9"
+         id="rect22" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,302.79999,215.99997)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath25">
+      <rect
+         y="85"
+         x="433"
+         height="22"
+         width="22"
+         fill="url(#3)"
+         color="#bebebe"
+         rx="4"
+         id="rect27" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0875,0,0,0.0875,430.9,81.499996)"
+       y1="291.43"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath30">
+      <rect
+         width="30"
+         height="30"
+         x="433"
+         y="37"
+         fill="url(#4)"
+         color="#bebebe"
+         rx="6"
+         id="rect32" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,430.13636,32.227267)"
+       y1="291.43"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath35">
+      <rect
+         width="16"
+         height="16"
+         x="304"
+         y="212"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#5)"
+         color="#bebebe"
+         rx="3"
+         id="rect37" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06666667,0,0,0.06666667,302.4,209.33333)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath40">
+      <rect
+         y="46"
+         x="34"
+         height="220"
+         width="220"
+         fill="url(#6)"
+         color="#bebebe"
+         rx="50"
+         id="rect42" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath45">
+      <rect
+         y="142"
+         x="290"
+         height="60"
+         width="60"
+         fill="url(#7)"
+         color="#bebebe"
+         rx="12.5"
+         id="rect47" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="7"
+       gradientUnits="userSpaceOnUse"
+       y1="204"
+       x2="0"
+       y2="140" />
+    <clipPath
+       id="clipPath50">
+      <rect
+         width="88"
+         height="88"
+         x="292"
+         y="32"
+         fill="url(#8)"
+         color="#bebebe"
+         rx="18"
+         id="rect52" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="8"
+       gradientUnits="userSpaceOnUse"
+       y1="124"
+       x2="0"
+       y2="28" />
+    <clipPath
+       id="clipPath55">
+      <rect
+         y="101"
+         x="417"
+         height="22"
+         width="22"
+         fill="url(#9)"
+         color="#bebebe"
+         rx="5"
+         id="rect57" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0875,0,0,0.0875,414.9,97.5)"
+       y1="302.86"
+       x2="0"
+       y2="28.571" />
+    <clipPath
+       id="clipPath60">
+      <rect
+         width="30"
+         height="30"
+         x="417"
+         y="53"
+         fill="url(#A)"
+         color="#bebebe"
+         rx="7"
+         id="rect62" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="A"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,414.13636,48.22727)"
+       y1="299.81"
+       x2="0"
+       y2="31.619" />
+    <use
+       id="B"
+       opacity="0.2"
+       fill="#ffffff"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath66">
+      <use
+         xlink:href="#B"
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         id="use68" />
+    </clipPath>
+    <clipPath
+       id="clipPath70">
+      <use
+         xlink:href="#B"
+         id="use72" />
+    </clipPath>
+    <use
+       id="C"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath75">
+      <use
+         xlink:href="#C"
+         id="use77" />
+    </clipPath>
+    <clipPath
+       id="clipPath79">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#C"
+         id="use81" />
+    </clipPath>
+    <use
+       id="D"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath84">
+      <use
+         xlink:href="#D"
+         id="use86" />
+    </clipPath>
+    <clipPath
+       id="clipPath88">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#D"
+         id="use90" />
+    </clipPath>
+    <use
+       id="E"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath93">
+      <use
+         xlink:href="#E"
+         id="use95" />
+    </clipPath>
+    <clipPath
+       id="clipPath97">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#E"
+         id="use99" />
+    </clipPath>
+    <use
+       id="F"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath102">
+      <use
+         xlink:href="#F"
+         id="use104" />
+    </clipPath>
+    <clipPath
+       id="clipPath106">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#F"
+         id="use108" />
+    </clipPath>
+    <use
+       id="G"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath111">
+      <use
+         xlink:href="#G"
+         id="use113" />
+    </clipPath>
+    <clipPath
+       id="clipPath115">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#G"
+         id="use117" />
+    </clipPath>
+    <use
+       id="H"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath120">
+      <use
+         xlink:href="#H"
+         id="use122" />
+    </clipPath>
+    <clipPath
+       id="clipPath124">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#H"
+         id="use126" />
+    </clipPath>
+    <use
+       id="I"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath129">
+      <use
+         xlink:href="#I"
+         id="use131" />
+    </clipPath>
+    <clipPath
+       id="clipPath133">
+      <rect
+         y="223"
+         x="307"
+         height="42"
+         width="42"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#2)"
+         color="#bebebe"
+         rx="9"
+         id="rect135" />
+    </clipPath>
+    <clipPath
+       id="clipPath137">
+      <rect
+         y="85"
+         x="433"
+         height="22"
+         width="22"
+         fill="url(#3)"
+         color="#bebebe"
+         rx="4"
+         id="rect139" />
+    </clipPath>
+    <clipPath
+       id="clipPath141">
+      <rect
+         width="30"
+         height="30"
+         x="433"
+         y="37"
+         fill="url(#4)"
+         color="#bebebe"
+         rx="6"
+         id="rect143" />
+    </clipPath>
+    <clipPath
+       id="clipPath145">
+      <rect
+         width="16"
+         height="16"
+         x="304"
+         y="212"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#5)"
+         color="#bebebe"
+         rx="3"
+         id="rect147" />
+    </clipPath>
+    <clipPath
+       id="clipPath149">
+      <rect
+         y="46"
+         x="34"
+         height="220"
+         width="220"
+         fill="url(#6)"
+         color="#bebebe"
+         rx="50"
+         id="rect151" />
+    </clipPath>
+    <clipPath
+       id="clipPath153">
+      <rect
+         y="142"
+         x="290"
+         height="60"
+         width="60"
+         fill="url(#7)"
+         color="#bebebe"
+         rx="12.5"
+         id="rect155" />
+    </clipPath>
+    <clipPath
+       id="clipPath157">
+      <rect
+         width="88"
+         height="88"
+         x="292"
+         y="32"
+         fill="url(#8)"
+         color="#bebebe"
+         rx="18"
+         id="rect159" />
+    </clipPath>
+    <clipPath
+       id="clipPath161">
+      <rect
+         y="101"
+         x="417"
+         height="22"
+         width="22"
+         fill="url(#9)"
+         color="#bebebe"
+         rx="5"
+         id="rect163" />
+    </clipPath>
+    <clipPath
+       id="clipPath165">
+      <rect
+         width="30"
+         height="30"
+         x="417"
+         y="53"
+         fill="url(#A)"
+         color="#bebebe"
+         rx="7"
+         id="rect167" />
+    </clipPath>
+    <clipPath
+       id="clipPath169">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#I"
+         id="use171" />
+    </clipPath>
+    <use
+       id="J"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath174">
+      <use
+         xlink:href="#J"
+         id="use176" />
+    </clipPath>
+    <clipPath
+       id="clipPath178">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#J"
+         id="use180" />
+    </clipPath>
+    <use
+       id="K"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath183">
+      <use
+         xlink:href="#K"
+         id="use185" />
+    </clipPath>
+    <clipPath
+       id="clipPath187">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#K"
+         id="use189" />
+    </clipPath>
+    <use
+       id="L"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath192">
+      <use
+         xlink:href="#L"
+         id="use194" />
+    </clipPath>
+    <clipPath
+       id="clipPath196">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#L"
+         id="use198" />
+    </clipPath>
+    <use
+       id="M"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath201">
+      <use
+         xlink:href="#M"
+         id="use203" />
+    </clipPath>
+    <clipPath
+       id="clipPath205">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#M"
+         id="use207" />
+    </clipPath>
+    <use
+       id="N"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath210">
+      <use
+         xlink:href="#N"
+         id="use212" />
+    </clipPath>
+    <clipPath
+       id="clipPath214">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#N"
+         id="use216" />
+    </clipPath>
+    <use
+       id="O"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath219">
+      <use
+         xlink:href="#O"
+         id="use221" />
+    </clipPath>
+    <clipPath
+       id="clipPath223">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#O"
+         id="use225" />
+    </clipPath>
+    <clipPath
+       id="clipPath227">
+      <path
+         d="m 296,26 a 10,10 0 1 1 -20,0 10,10 0 1 1 20,0 z"
+         id="path229" />
+    </clipPath>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="40"
+       y1="280"
+       xlink:href="#Q"
+       id="P"
+       gradientTransform="matrix(.175 0 0 .175 302.79999 215.99997)" />
+    <linearGradient
+       id="Q">
+      <stop
+         stop-color="#151515"
+         id="stop233" />
+      <stop
+         offset="1"
+         stop-color="#222"
+         id="stop235" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="90"
+       y1="230"
+       xlink:href="#Q"
+       id="R"
+       gradientTransform="matrix(.375 0 0 .375 298 16)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="90"
+       y1="230"
+       xlink:href="#Q"
+       id="S"
+       gradientTransform="matrix(.25 0 0 .25 299.99999 131.99999)" />
+    <clipPath
+       id="clipPath239">
+      <rect
+         height="20"
+         rx="4"
+         y="78"
+         x="434"
+         width="20"
+         color="#bebebe"
+         id="rect241" />
+    </clipPath>
+    <clipPath
+       id="clipPath243">
+      <rect
+         height="22"
+         rx="4"
+         y="77"
+         x="433"
+         width="22"
+         color="#bebebe"
+         id="rect245" />
+    </clipPath>
+    <clipPath
+       id="clipPath247">
+      <rect
+         height="22"
+         rx="5"
+         y="77"
+         x="433"
+         width="22"
+         color="#bebebe"
+         id="rect249" />
+    </clipPath>
+    <clipPath
+       id="clipPath251">
+      <rect
+         height="30"
+         rx="6"
+         y="29"
+         x="433"
+         width="30"
+         color="#bebebe"
+         id="rect253" />
+    </clipPath>
+    <clipPath
+       id="clipPath255">
+      <rect
+         transform="matrix(0 -1 1 0 0 0)"
+         height="60"
+         rx="12.5"
+         y="142"
+         x="306"
+         width="60"
+         fill="url(#S)"
+         color="#bebebe"
+         id="rect257" />
+    </clipPath>
+    <clipPath
+       id="clipPath259">
+      <rect
+         height="90"
+         rx="18.75"
+         y="31"
+         x="307"
+         width="90"
+         fill="url(#R)"
+         color="#bebebe"
+         id="rect261" />
+    </clipPath>
+    <clipPath
+       id="clipPath263">
+      <rect
+         height="30"
+         rx="4"
+         y="29"
+         x="433"
+         width="30"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect265" />
+    </clipPath>
+    <clipPath
+       id="clipPath267">
+      <rect
+         height="22"
+         rx="3"
+         y="77"
+         x="433"
+         width="22"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect269" />
+    </clipPath>
+    <clipPath
+       id="clipPath271">
+      <path
+         d="m 144,70 c -49.705627,0 -90,40.29437 -90,90 0,49.70563 40.294373,90 90,90 49.70563,0 90,-40.29437 90,-90 0,-49.70563 -40.29437,-90 -90,-90 z m 0,32.1875 c 32.03251,0 58,25.96748 58,58 0,32.03252 -25.96749,58 -58,58 -32.03251,0 -58,-25.96748 -58,-58 0,-32.03252 25.96749,-58 58,-58 z"
+         id="path273" />
+    </clipPath>
+    <clipPath
+       id="clipPath275">
+      <path
+         d="m 152,204 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         id="path277" />
+    </clipPath>
+    <clipPath
+       id="clipPath279">
+      <rect
+         height="16"
+         rx="3"
+         y="116"
+         x="432"
+         width="16"
+         color="#bebebe"
+         id="rect281" />
+    </clipPath>
+    <clipPath
+       id="clipPath283">
+      <path
+         d="m 145,215 c 33.13708,0 60,-26.86292 60,-60 0,-33.13708 -26.86292,-60 -60,-60 -33.13708,0 -60,26.86292 -60,60 0,12.50698 3.8285,24.10633 10.375,33.71875 L 89,211 111.28125,204.625 C 120.89367,211.1715 132.49302,215 145,215 z"
+         id="path285" />
+    </clipPath>
+    <clipPath
+       id="clipPath287">
+      <path
+         d="m 98.03125,23.191212 c -41.492132,1.05238 -74.84375,35.06824 -74.84375,76.812498 0,42.40687 34.405632,76.8125 76.8125,76.8125 42.40687,0 76.8125,-34.40563 76.8125,-76.8125 0,-42.406866 -34.40563,-76.812498 -76.8125,-76.812498 -0.662607,0 -1.310145,-0.0167 -1.96875,0 z M 100,50.659962 c 27.24464,0 49.34375,22.099114 49.34375,49.343748 -1e-5,27.24464 -22.09911,49.34375 -49.34375,49.34375 -27.244636,-1e-5 -49.34375,-22.09911 -49.34375,-49.34375 0,-27.244634 22.099114,-49.343748 49.34375,-49.343748 z"
+         id="path289" />
+    </clipPath>
+    <clipPath
+       id="clipPath291">
+      <rect
+         height="16"
+         rx="2"
+         y="116"
+         x="432"
+         width="16"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect293" />
+    </clipPath>
+    <clipPath
+       id="clipPath295">
+      <rect
+         height="240"
+         rx="50"
+         y="36"
+         x="24"
+         width="240"
+         fill="#986767"
+         color="#bebebe"
+         id="rect297" />
+    </clipPath>
+    <clipPath
+       id="clipPath299">
+      <rect
+         transform="rotate(90)"
+         height="42"
+         rx="9"
+         y="223"
+         x="307"
+         width="42"
+         fill="url(#P)"
+         color="#bebebe"
+         id="rect301" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#0"
+       id="T"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.210546,0,0,1.212299,-131.34805,-325.07347)"
+       y1="279.1"
+       x2="0"
+       y2="268.33" />
+    <path
+       id="U"
+       d="m 296,26 a 10,10 0 1 1 -20,0 10,10 0 1 1 20,0 z"
+       color="#000000" />
+    <linearGradient
+       xlink:href="#W"
+       id="V"
+       y1="46.752"
+       x2="0"
+       y2="-24.433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="W">
+      <stop
+         stop-color="#c7c7c7"
+         id="stop307" />
+      <stop
+         offset="1"
+         stop-color="#dedede"
+         id="stop309" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#W"
+       id="linearGradient3312"
+       gradientUnits="userSpaceOnUse"
+       y1="46.752"
+       x2="0"
+       y2="-24.433"
+       gradientTransform="matrix(0.23630483,0,0,0.18633729,-11.350379,4.8349746)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#W-1"
+       id="linearGradient3312-3"
+       gradientUnits="userSpaceOnUse"
+       y1="46.751999"
+       x2="0"
+       y2="-24.433001"
+       gradientTransform="matrix(0.23630483,0,0,0.18633729,-11.350379,4.8349746)" />
+    <linearGradient
+       id="W-1">
+      <stop
+         stop-color="#c7c7c7"
+         id="stop307-9" />
+      <stop
+         offset="1"
+         stop-color="#dedede"
+         id="stop309-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#1"
+       id="linearGradient3938"
+       x1="7.0555558"
+       y1="13.264444"
+       x2="6.7733335"
+       y2="0.28222224"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient3990"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient3992"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4001"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4008"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4013"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4015"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4022"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4024"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4031"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4036"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4460"
+       id="linearGradient3019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.10525,0,0,1.10525,-148.53723,-295.81487)"
+       y1="279.09601"
+       x2="0"
+       y2="268.32999" />
+    <linearGradient
+       id="linearGradient4460">
+      <stop
+         offset="0"
+         style="stop-color:#1d1d1d"
+         id="stop7-3" />
+      <stop
+         offset="1"
+         style="stop-color:#333"
+         id="stop9-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3798"
+       id="linearGradient3804"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3798">
+      <stop
+         style="stop-color:#654343;stop-opacity:1;"
+         offset="0"
+         id="stop3800" />
+      <stop
+         style="stop-color:#714b4b;stop-opacity:1;"
+         offset="1"
+         id="stop3802" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28222223,0,0,0.28222223,14.970031,0.21737973)"
+       y2="1"
+       x2="24"
+       y1="47"
+       x1="24"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3244"
+       xlink:href="#linearGradient3798"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(0,-1004.3622)"
+       y2="1047.36"
+       x2="0"
+       y1="1028.36"
+       gradientUnits="userSpaceOnUse"
+       id="0-8"
+       xlink:href="#1-8" />
+    <linearGradient
+       id="1-8">
+      <stop
+         stop-color="#ffffff"
+         id="stop3236" />
+      <stop
+         offset="1"
+         stop-color="#ffffff"
+         stop-opacity="0"
+         id="stop3238" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#3-9"
+       id="2-6"
+       gradientUnits="userSpaceOnUse"
+       y1="1028.36"
+       x2="0"
+       y2="1047.36"
+       gradientTransform="matrix(1,0,0,-1,0,1052.3622)" />
+    <linearGradient
+       id="3-9">
+      <stop
+         id="stop3242" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop3244" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.10525,0,0,1.10525,-134.22541,-295.81514)"
+       xlink:href="#linearGradient4460-7"
+       id="linearGradient4902"
+       y1="279.09601"
+       y2="268.32999"
+       gradientUnits="userSpaceOnUse"
+       x2="0" />
+    <linearGradient
+       id="linearGradient4460-7">
+      <stop
+         offset="0"
+         style="stop-color:#3c2828"
+         id="stop7-6" />
+      <stop
+         offset="1"
+         style="stop-color:#604040"
+         id="stop9-0" />
+    </linearGradient>
+    <linearGradient
+       y2="268.32999"
+       x2="0"
+       y1="279.09601"
+       gradientTransform="matrix(1.10525,0,0,1.10525,-134.22541,-295.81514)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3038"
+       xlink:href="#linearGradient4460-7"
+       inkscape:collect="always" />
+    <radialGradient
+       xlink:href="#0-6"
+       id="6-9"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="0-6">
+      <stop
+         stop-color="#91b0c7"
+         id="stop7-0" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop9-3" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="radialGradient3889"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3891">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3893" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3895" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="5-0"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3898">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3900" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3902" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="radialGradient3904"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3908" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3910" />
+    </linearGradient>
+    <radialGradient
+       r="10"
+       cy="24"
+       cx="-3"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3922"
+       xlink:href="#0-6"
+       inkscape:collect="always" />
+    <radialGradient
+       xlink:href="#0-7"
+       id="5-4"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="0-7">
+      <stop
+         stop-color="#91b0c7"
+         id="stop7-8" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop9-2" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="radialGradient3960"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3962">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3964" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3966" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="6-8"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3969">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3971" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3973" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="radialGradient3975"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3979" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3981" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4121-1"
+       id="radialGradient4127-8"
+       cx="6.7733335"
+       cy="5.9266667"
+       fx="6.7733335"
+       fy="5.9266667"
+       r="0.56444442"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4121-1">
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:1;"
+         offset="0"
+         id="stop4123-7" />
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:0;"
+         offset="1"
+         id="stop4125-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4073"
+       id="linearGradient4079"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Shadow"
+     sodipodi:insensitive="true">
+    <path
+       style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 25,2 C 12.297451,2 2,12.297451 2,25 2,31.367153 4.6007106,37.116628 8.78125,41.28125 12.865755,44.99361 18.29568,47.25 24.25,47.25 c 12.702549,0 23,-10.297451 23,-23 0,-5.95432 -2.25639,-11.384245 -5.96875,-15.46875 C 37.116628,4.6007105 31.367153,2 25,2 z M 41.28125,8.78125 C 45.135604,12.894061 47.5,18.418655 47.5,24.5 c 0,12.702549 -10.297451,23 -23,23 C 18.418655,47.5 12.894061,45.135604 8.78125,41.28125 12.940939,45.4251 18.664604,48 25,48 37.702549,48 48,37.702549 48,25 48,18.664604 45.4251,12.940939 41.28125,8.78125 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3978"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 41.28125,8.78125 C 44.99361,12.865755 47.25,18.29568 47.25,24.25 c 0,12.702549 -10.297451,23 -23,23 -5.95432,0 -11.384245,-2.25639 -15.46875,-5.96875 C 12.894061,45.135604 18.418655,47.5 24.5,47.5 c 12.702549,0 23,-10.297451 23,-23 0,-6.081345 -2.364396,-11.605939 -6.21875,-15.71875 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3976"
+       inkscape:connector-curvature="0" />
+    <path
+       transform="matrix(4.3274074,0,0,3.2455556,117.19278,-35.348334)"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       sodipodi:ry="2"
+       sodipodi:rx="1.5"
+       sodipodi:cy="13"
+       sodipodi:cx="-25.5"
+       id="path3952"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       sodipodi:type="arc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Base">
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:url(#linearGradient4079);fill-opacity:1.0;stroke:none"
+       id="path3942"
+       sodipodi:cx="-25.5"
+       sodipodi:cy="13"
+       sodipodi:rx="1.5"
+       sodipodi:ry="2"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       transform="matrix(4.3274075,0,0,3.2455556,117.12222,-35.418889)" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 40.03125 7.53125 C 43.74361 11.615755 46 17.04568 46 23 C 46 35.702549 35.702549 46 23 46 C 17.04568 46 11.615755 43.74361 7.53125 40.03125 C 11.709416 44.322508 17.537578 47 24 47 C 36.702549 47 47 36.702549 47 24 C 47 17.537578 44.322508 11.709416 40.03125 7.53125 z "
+       id="path4027"
+       transform="scale(0.28222223,0.28222223)" />
+    <use
+       id="use102"
+       xlink:href="#7"
+       transform="matrix(0.39511112,0,0,0.39511112,7.9586669,-2.4271114)"
+       style="opacity:0.2"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use104-7"
+       xlink:href="#7"
+       transform="matrix(0.39511112,0,0,0.39511112,7.9586669,-2.7093336)"
+       style="fill:#f9f9f9"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use108-3"
+       xlink:href="#7"
+       transform="matrix(0.31044445,0,0,0.31044445,7.7046669,-0.67733354)"
+       style="fill:#355464"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use110"
+       xlink:href="#7"
+       transform="matrix(0.22577778,0,0,0.22577778,7.4506669,1.3546665)"
+       style="fill:#566d80"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use112"
+       xlink:href="#7"
+       transform="matrix(0.16933334,0,0,0.16933334,7.2813335,2.7093332)"
+       style="fill:#355464"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use114"
+       xlink:href="#7"
+       transform="matrix(0.05644445,0,0,0.05644445,6.9426669,4.5719999)"
+       style="fill:url(#6-9)"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use116"
+       xlink:href="#7"
+       transform="matrix(0.02822222,0,0,0.02822222,6.8580002,6.6604444)"
+       style="fill:url(#radialGradient3922)"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Symbol">
+    <g
+       transform="matrix(0.04837074,0,0,0.04515119,-8.7276404,2.501281)"
+       id="g4060" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3271"
+       width="20.564056"
+       height="20.798693"
+       x="13.718385"
+       y="13.595851"
+       ry="0.013342512"
+       transform="scale(0.28222223,0.28222223)" />
+    <g
+       id="g2997"
+       transform="matrix(0.04837074,0,0,0.04515119,2.6141654,2.4836422)">
+      <path
+         style="fill:#859fad;fill-opacity:1"
+         d="m 16.3125,12.5 0,1.59375 -1.71875,0 0,1.59375 0,8.8125 0,8.8125 0,1.59375 1.71875,0 0,1.59375 1.71875,0 17.125,0 1.71875,0 0,-1.59375 1.71875,0 0,-1.59375 0,-8.8125 0,-8.8125 0,-1.59375 -1.71875,0 0,-1.59375 -1.71875,0 -8.5625,0 -8.5625,0 -1.71875,0 z m 1.71875,1.59375 8.5625,0 8.5625,0 0,0.8125 0,0.78125 0.875,0 0.84375,0 0,7.21875 0,7.1875 -0.84375,0 -0.875,0 0,0.8125 0,0.78125 -8.5625,0 -8.5625,0 0,-0.78125 0,-0.8125 -0.875,0 -0.84375,0 0,-7.1875 0,-7.21875 0.84375,0 0.875,0 0,-0.78125 0,-0.8125 z m 3.4375,4.8125 0,3.1875 0,3.21875 0.84375,0 0.84375,0 0,-3.21875 0,-3.1875 -0.84375,0 -0.84375,0 z m 8.5625,0 0,3.1875 0,3.21875 0.84375,0 0.875,0 0,-3.21875 0,-3.1875 -0.875,0 -0.84375,0 z"
+         transform="matrix(5.8333338,0,0,6.2499995,-69.159789,-58.110459)"
+         id="path3003"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#645460"
+         d="m 36,165 0,-5 -5,0 -5,0 0,-5 0,-5 -5,0 -5,0 0,-55 0,-55 c 3.333333,0 6.666667,0 10,0 0,-3.333333 0,-6.666667 0,-10 3.333333,0 6.666667,0 10,0 0,-3.333333 0,-6.666667 0,-10 33.333333,0 66.66667,0 100,0 l 0,5 0,5 5,0 5,0 0,5 0,5 5,0 5,0 0,55 0,55 -5,0 -5,0 0,5 0,5 -5,0 -5,0 0,5 0,5 -50,0 -50,0 z m 100,-10 0,-5 5,0 5,0 0,-55 0,-55 -5,0 -5,0 0,-5 0,-5 c -33.33333,0 -66.666667,0 -100,0 0,3.333333 0,6.666667 0,10 -3.333333,0 -6.666667,0 -10,0 l 0,55 0,55 5,0 5,0 0,5 0,5 50,0 50,0 z m -80,-75 0,-20 5,0 5,0 0,20 0,20 -5,0 -5,0 z m 50,0 0,-20 5,0 5,0 0,20 0,20 -5,0 -5,0 z"
+         id="path2999"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/bygfoot.svg
+++ b/Numix-Circle/48x48/apps/bygfoot.svg
@@ -1,0 +1,299 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="bygfoot.svg">
+  <metadata
+     id="metadata42">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview40"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="24.762067"
+     inkscape:cy="22.604153"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3820" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3844">
+      <stop
+         style="stop-color:#dd0000;stop-opacity:1;"
+         offset="0"
+         id="stop3846" />
+      <stop
+         style="stop-color:#d20000;stop-opacity:1;"
+         offset="1"
+         id="stop3848" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3795">
+      <stop
+         style="stop-color:#249e24;stop-opacity:1;"
+         offset="0"
+         id="stop3797" />
+      <stop
+         style="stop-color:#208e20;stop-opacity:1;"
+         offset="1"
+         id="stop3799" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3787">
+      <stop
+         style="stop-color:#36d536;stop-opacity:1;"
+         offset="0"
+         id="stop3789" />
+      <stop
+         style="stop-color:#2bcd2b;stop-opacity:0.99215686;"
+         offset="1"
+         id="stop3791" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3779">
+      <stop
+         style="stop-color:#36d536;stop-opacity:1;"
+         offset="0"
+         id="stop3781" />
+      <stop
+         style="stop-color:#2cd02c;stop-opacity:1;"
+         offset="1"
+         id="stop3783" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3769">
+      <stop
+         style="stop-color:#37d537;stop-opacity:1;"
+         offset="0"
+         id="stop3771" />
+      <stop
+         style="stop-color:#2cd02c;stop-opacity:1;"
+         offset="1"
+         id="stop3773" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5349"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#249e24;stop-opacity:1;"
+         offset="0"
+         id="stop5351" />
+    </linearGradient>
+    <clipPath
+       id="clipPath6">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g8">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path10" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath12">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g14">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path16" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3769"
+       id="linearGradient3775"
+       x1="1.0719092"
+       y1="6.5989819"
+       x2="1.0180827"
+       y2="41.403019"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3779"
+       id="linearGradient3785"
+       x1="47.053825"
+       y1="6.6698914"
+       x2="47.071911"
+       y2="41.40202"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3787"
+       id="linearGradient3793"
+       x1="24.033642"
+       y1="0.91765791"
+       x2="24.038267"
+       y2="47.08334"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3795"
+       id="linearGradient3801"
+       x1="18.851555"
+       y1="1.7086587"
+       x2="18.856182"
+       y2="46.36425"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3795"
+       id="linearGradient3809"
+       x1="29"
+       y1="1.6276183"
+       x2="29.135593"
+       y2="46.576771"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3844"
+       id="linearGradient3037"
+       gradientUnits="userSpaceOnUse"
+       x1="120.46027"
+       y1="2.1447911"
+       x2="125.54502"
+       y2="192.84227" />
+  </defs>
+  <g
+     id="g18">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path20" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path22" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path24" />
+  </g>
+  <path
+     d="m 24 1 c -1.721 0 -3.387 0.204 -5 0.563 l 0 44.875 c 1.613 0.358 3.279 0.563 5 0.563 c 1.721 0 3.387 -0.204 5 -0.563 l 0 -44.875 c -1.613 -0.358 -3.279 -0.563 -5 -0.563 z"
+     fill="#f3f284"
+     fill-rule="nonzero"
+     stroke="none"
+     fill-opacity="1"
+     id="path26"
+     style="fill:url(#linearGradient3793);fill-opacity:1.0" />
+  <path
+     d="m 9 6.563 c -4.897 4.218 -8 10.467 -8 17.438 c 0 6.971 3.103 13.22 8 17.438 l 0 -34.875 z"
+     id="path28"
+     style="fill:url(#linearGradient3775);fill-opacity:1"
+     stroke="none"
+     fill-rule="nonzero"
+     fill-opacity="1"
+     fill="#9ab9dd" />
+  <path
+     d="m 19 1.563 c -3.76 0.835 -7.182 2.573 -10 5 l 0 34.875 c 2.818 2.427 6.24 4.165 10 5 l 0 -44.875 z"
+     fill="#9add9c"
+     fill-rule="nonzero"
+     stroke="none"
+     fill-opacity="1"
+     id="path30"
+     style="fill:url(#linearGradient3801);fill-opacity:1.0" />
+  <path
+     d="m 29 1.563 l 0 44.875 c 3.76 -0.835 7.182 -2.573 10 -5 l 0 -34.875 c -2.818 -2.427 -6.24 -4.165 -10 -5 z"
+     id="path32"
+     style="fill:url(#linearGradient3809);fill-opacity:1"
+     stroke="none"
+     fill-rule="nonzero"
+     fill-opacity="1"
+     fill="#edb968" />
+  <path
+     d="m 39 6.563 l 0 34.875 c 4.897 -4.218 8 -10.467 8 -17.438 c 0 -6.971 -3.103 -13.22 -8 -17.438 z"
+     fill="#ed8e68"
+     fill-rule="nonzero"
+     stroke="none"
+     fill-opacity="1"
+     id="path34"
+     style="fill:url(#linearGradient3785);fill-opacity:1.0" />
+  <g
+     id="g36">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path38" />
+  </g>
+  <g
+     id="layer1"
+     transform="matrix(0.13055556,0,0,0.12387304,8.4732121,12.879598)"
+     style="fill:#000000;fill-opacity:0.28399999">
+    <path
+       d="M 210.96875,54.71875 199.7774,14.287856 184.46144,0.97199239 l -31.97771,0 c -23.66119,16.42689861 -36.85542,15.91973761 -61.03276,0 l -32.711696,0 L 44.52542,14.365174 30.96875,54.71875 l 30,20 2.881241,-16.156465 7.118759,136.156465 100,-5 5,-130 5,15 z"
+       id="path1307"
+       style="fill:#000000;fill-opacity:0.28399999;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc" />
+  </g>
+  <g
+     id="g3029"
+     transform="matrix(0.98948602,0,0,0.99317742,-0.22312075,1.0147187)">
+    <g
+       style="fill:#dd0000;fill-opacity:1"
+       transform="matrix(0.1319428,0,0,0.12472398,8.2668964,11.543635)"
+       id="layer1-4">
+      <path
+         sodipodi:nodetypes="ccccccccccccccc"
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3037);fill-opacity:1;fill-rule:evenodd;stroke:none"
+         id="path1307-2"
+         d="M 210.96875,54.71875 199.7774,14.287856 184.46144,0.97199239 l -30.9395,0 c -23.66119,16.42689861 -37.09925,15.91973761 -61.276595,0 l -33.506071,0 L 44.52542,14.365174 30.96875,54.71875 l 30,20 2.881241,-16.156465 7.118759,136.156465 100,-5 5,-130 5,15 z" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path5797"
+       d="m 19.750592,28.379872 0.0585,-1.318189 0.870233,-0.07462 c 0,0 0.181786,-3.281162 0.338134,-5.884034 l -1.073464,0.33854 0.239671,-1.901195 2.884816,-0.869577 -0.448774,8.169252 0.869258,-0.07553 -0.05344,1.331499 z"
+       style="fill:#ffffff;fill-opacity:1" />
+    <path
+       style="fill:#ffffff;fill-opacity:1"
+       d="m 24.913954,28.379872 0.0585,-1.318189 0.870234,-0.07462 c 0,0 0.181786,-3.281162 0.338134,-5.884034 l -1.07347,0.338539 0.239671,-1.901195 2.884821,-0.869576 -0.448774,8.169251 0.869259,-0.07553 -0.05344,1.331499 z"
+       id="path3769"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/kbibtex.svg
+++ b/Numix-Circle/48x48/apps/kbibtex.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="kbibtex.svg">
+  <metadata
+     id="metadata71">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview69"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="22.220339"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       y1="47"
+       x2="0"
+       y2="1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#896372"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#946b7b"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-392676492">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-412190129">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33">
+    <g
+       clip-path="url(#clipPath-392676492)"
+       id="g35">
+      <g
+         transform="translate(1,1)"
+         id="g37">
+        <g
+           opacity="0.1"
+           id="g39">
+          <!-- color: #946b7b -->
+          <g
+             id="g41">
+            <path
+               d="M 11.6875 8 C 10.75 8 10 8.75 10 9.6875 L 10 15 L 18 15 L 18 9.6875 C 18 8.75 17.25 8 16.3125 8 Z M 10 16 L 10 32 L 18 32 L 18 16 Z M 10 33 L 10 38.3125 C 10 39.25 10.75 40 11.6875 40 L 16.3125 40 C 17.25 40 18 39.25 18 38.3125 L 18 33 Z M 10 33 "
+               fill="#000"
+               id="path43" />
+            <path
+               d="m 20.996 17.996 l 3 0 c 0.551 0 0.996 0.449 0.996 1 l 0 20 c 0 0.555 -0.445 1 -0.996 1 l -3 0 c -0.551 0 -0.996 -0.445 -0.996 -1 l 0 -20 c 0 -0.551 0.445 -1 0.996 -1 m 0 0"
+               fill="#000"
+               id="path45" />
+            <path
+               d="m 24.5 14.13 c 2.09 0.793 2.984 -0.305 2.984 -0.305 l 2.641 25.867 c -2.094 -0.793 -2.984 0.305 -2.984 0.305 m -2.641 -25.867"
+               fill="#000"
+               id="path47" />
+            <path
+               d="m 28 20.668 c 2.641 -1.742 5.797 -1.555 5.797 -1.555 l 5.176 19.32 c 0 0 -2.641 1.742 -5.797 1.551 m -5.176 -19.316"
+               fill="#000"
+               id="path49" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     id="g51">
+    <g
+       clip-path="url(#clipPath-412190129)"
+       id="g53">
+      <!-- color: #946b7b -->
+      <g
+         id="g55">
+        <path
+           d="M 11.6875 8 C 10.75 8 10 8.75 10 9.6875 L 10 15 L 18 15 L 18 9.6875 C 18 8.75 17.25 8 16.3125 8 Z M 10 16 L 10 32 L 18 32 L 18 16 Z M 10 33 L 10 38.3125 C 10 39.25 10.75 40 11.6875 40 L 16.3125 40 C 17.25 40 18 39.25 18 38.3125 L 18 33 Z M 10 33 "
+           fill="#fff472"
+           id="path57" />
+        <path
+           d="m 20.996 17.996 l 3 0 c 0.551 0 0.996 0.449 0.996 1 l 0 20 c 0 0.555 -0.445 1 -0.996 1 l -3 0 c -0.551 0 -0.996 -0.445 -0.996 -1 l 0 -20 c 0 -0.551 0.445 -1 0.996 -1 m 0 0"
+           fill="#ff947c"
+           id="path59"
+           style="fill:#ff957d;fill-opacity:1" />
+        <path
+           d="m 24.5 14.13 c 2.09 0.793 2.984 -0.305 2.984 -0.305 l 2.641 25.867 c -2.094 -0.793 -2.984 0.305 -2.984 0.305 m -2.641 -25.867"
+           fill="#8bc8ff"
+           id="path61" />
+        <path
+           d="m 28 20.668 c 2.641 -1.742 5.797 -1.555 5.797 -1.555 l 5.176 19.32 c 0 0 -2.641 1.742 -5.797 1.551 m -5.176 -19.316"
+           fill="#f9994c"
+           id="path63" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g65">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path67" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/lingot-icon.svg
+++ b/Numix-Circle/48x48/apps/lingot-icon.svg
@@ -1,0 +1,1449 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 13.546667 13.546667"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="lingot.svg">
+  <metadata
+     id="metadata331">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview329"
+     showgrid="false"
+     inkscape:zoom="18.737102"
+     inkscape:cx="23.414301"
+     inkscape:cy="22.214445"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2"
+     inkscape:snap-to-guides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3308" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4073">
+      <stop
+         style="stop-color:#fccc4e;stop-opacity:1;"
+         offset="0"
+         id="stop4075" />
+      <stop
+         style="stop-color:#fcd262;stop-opacity:1;"
+         offset="1"
+         id="stop4077" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4121">
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:1;"
+         offset="0"
+         id="stop4123" />
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:0;"
+         offset="1"
+         id="stop4125" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#3d3d3d;stop-opacity:1;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="0">
+      <stop
+         stop-color="#198ba6"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#42c9e7"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath11">
+      <path
+         d="m 489.217,197.275 c -2.603,0 -3.953,-1.367 -3.953,-3.971 l 0,0 0,-1.034 c 0,-2.604 1.35,-3.971 3.953,-3.971 l 0,0 1.035,0 c 2.62,0 3.97,1.367 3.97,3.971 l 0,0 0,1.034 c 0,2.604 -1.35,3.971 -3.97,3.971 l 0,0 -1.035,0 z"
+         id="path13" />
+    </clipPath>
+    <linearGradient
+       id="1">
+      <stop
+         stop-color="#620000"
+         id="stop16"
+         offset="0"
+         style="stop-color:#f96963;stop-opacity:1;" />
+      <stop
+         offset="1"
+         stop-color="#dd0f0f"
+         id="stop18"
+         style="stop-color:#f96963;stop-opacity:1;" />
+    </linearGradient>
+    <clipPath
+       id="clipPath20">
+      <rect
+         y="223"
+         x="307"
+         height="42"
+         width="42"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#2)"
+         color="#bebebe"
+         rx="9"
+         id="rect22" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,302.79999,215.99997)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath25">
+      <rect
+         y="85"
+         x="433"
+         height="22"
+         width="22"
+         fill="url(#3)"
+         color="#bebebe"
+         rx="4"
+         id="rect27" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0875,0,0,0.0875,430.9,81.499996)"
+       y1="291.43"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath30">
+      <rect
+         width="30"
+         height="30"
+         x="433"
+         y="37"
+         fill="url(#4)"
+         color="#bebebe"
+         rx="6"
+         id="rect32" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,430.13636,32.227267)"
+       y1="291.43"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath35">
+      <rect
+         width="16"
+         height="16"
+         x="304"
+         y="212"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#5)"
+         color="#bebebe"
+         rx="3"
+         id="rect37" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06666667,0,0,0.06666667,302.4,209.33333)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath40">
+      <rect
+         y="46"
+         x="34"
+         height="220"
+         width="220"
+         fill="url(#6)"
+         color="#bebebe"
+         rx="50"
+         id="rect42" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath45">
+      <rect
+         y="142"
+         x="290"
+         height="60"
+         width="60"
+         fill="url(#7)"
+         color="#bebebe"
+         rx="12.5"
+         id="rect47" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="7"
+       gradientUnits="userSpaceOnUse"
+       y1="204"
+       x2="0"
+       y2="140" />
+    <clipPath
+       id="clipPath50">
+      <rect
+         width="88"
+         height="88"
+         x="292"
+         y="32"
+         fill="url(#8)"
+         color="#bebebe"
+         rx="18"
+         id="rect52" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="8"
+       gradientUnits="userSpaceOnUse"
+       y1="124"
+       x2="0"
+       y2="28" />
+    <clipPath
+       id="clipPath55">
+      <rect
+         y="101"
+         x="417"
+         height="22"
+         width="22"
+         fill="url(#9)"
+         color="#bebebe"
+         rx="5"
+         id="rect57" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0875,0,0,0.0875,414.9,97.5)"
+       y1="302.86"
+       x2="0"
+       y2="28.571" />
+    <clipPath
+       id="clipPath60">
+      <rect
+         width="30"
+         height="30"
+         x="417"
+         y="53"
+         fill="url(#A)"
+         color="#bebebe"
+         rx="7"
+         id="rect62" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="A"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,414.13636,48.22727)"
+       y1="299.81"
+       x2="0"
+       y2="31.619" />
+    <use
+       id="B"
+       opacity="0.2"
+       fill="#ffffff"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath66">
+      <use
+         xlink:href="#B"
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         id="use68" />
+    </clipPath>
+    <clipPath
+       id="clipPath70">
+      <use
+         xlink:href="#B"
+         id="use72" />
+    </clipPath>
+    <use
+       id="C"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath75">
+      <use
+         xlink:href="#C"
+         id="use77" />
+    </clipPath>
+    <clipPath
+       id="clipPath79">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#C"
+         id="use81" />
+    </clipPath>
+    <use
+       id="D"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath84">
+      <use
+         xlink:href="#D"
+         id="use86" />
+    </clipPath>
+    <clipPath
+       id="clipPath88">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#D"
+         id="use90" />
+    </clipPath>
+    <use
+       id="E"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath93">
+      <use
+         xlink:href="#E"
+         id="use95" />
+    </clipPath>
+    <clipPath
+       id="clipPath97">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#E"
+         id="use99" />
+    </clipPath>
+    <use
+       id="F"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath102">
+      <use
+         xlink:href="#F"
+         id="use104" />
+    </clipPath>
+    <clipPath
+       id="clipPath106">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#F"
+         id="use108" />
+    </clipPath>
+    <use
+       id="G"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath111">
+      <use
+         xlink:href="#G"
+         id="use113" />
+    </clipPath>
+    <clipPath
+       id="clipPath115">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#G"
+         id="use117" />
+    </clipPath>
+    <use
+       id="H"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath120">
+      <use
+         xlink:href="#H"
+         id="use122" />
+    </clipPath>
+    <clipPath
+       id="clipPath124">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#H"
+         id="use126" />
+    </clipPath>
+    <use
+       id="I"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath129">
+      <use
+         xlink:href="#I"
+         id="use131" />
+    </clipPath>
+    <clipPath
+       id="clipPath133">
+      <rect
+         y="223"
+         x="307"
+         height="42"
+         width="42"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#2)"
+         color="#bebebe"
+         rx="9"
+         id="rect135" />
+    </clipPath>
+    <clipPath
+       id="clipPath137">
+      <rect
+         y="85"
+         x="433"
+         height="22"
+         width="22"
+         fill="url(#3)"
+         color="#bebebe"
+         rx="4"
+         id="rect139" />
+    </clipPath>
+    <clipPath
+       id="clipPath141">
+      <rect
+         width="30"
+         height="30"
+         x="433"
+         y="37"
+         fill="url(#4)"
+         color="#bebebe"
+         rx="6"
+         id="rect143" />
+    </clipPath>
+    <clipPath
+       id="clipPath145">
+      <rect
+         width="16"
+         height="16"
+         x="304"
+         y="212"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#5)"
+         color="#bebebe"
+         rx="3"
+         id="rect147" />
+    </clipPath>
+    <clipPath
+       id="clipPath149">
+      <rect
+         y="46"
+         x="34"
+         height="220"
+         width="220"
+         fill="url(#6)"
+         color="#bebebe"
+         rx="50"
+         id="rect151" />
+    </clipPath>
+    <clipPath
+       id="clipPath153">
+      <rect
+         y="142"
+         x="290"
+         height="60"
+         width="60"
+         fill="url(#7)"
+         color="#bebebe"
+         rx="12.5"
+         id="rect155" />
+    </clipPath>
+    <clipPath
+       id="clipPath157">
+      <rect
+         width="88"
+         height="88"
+         x="292"
+         y="32"
+         fill="url(#8)"
+         color="#bebebe"
+         rx="18"
+         id="rect159" />
+    </clipPath>
+    <clipPath
+       id="clipPath161">
+      <rect
+         y="101"
+         x="417"
+         height="22"
+         width="22"
+         fill="url(#9)"
+         color="#bebebe"
+         rx="5"
+         id="rect163" />
+    </clipPath>
+    <clipPath
+       id="clipPath165">
+      <rect
+         width="30"
+         height="30"
+         x="417"
+         y="53"
+         fill="url(#A)"
+         color="#bebebe"
+         rx="7"
+         id="rect167" />
+    </clipPath>
+    <clipPath
+       id="clipPath169">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#I"
+         id="use171" />
+    </clipPath>
+    <use
+       id="J"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath174">
+      <use
+         xlink:href="#J"
+         id="use176" />
+    </clipPath>
+    <clipPath
+       id="clipPath178">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#J"
+         id="use180" />
+    </clipPath>
+    <use
+       id="K"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath183">
+      <use
+         xlink:href="#K"
+         id="use185" />
+    </clipPath>
+    <clipPath
+       id="clipPath187">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#K"
+         id="use189" />
+    </clipPath>
+    <use
+       id="L"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath192">
+      <use
+         xlink:href="#L"
+         id="use194" />
+    </clipPath>
+    <clipPath
+       id="clipPath196">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#L"
+         id="use198" />
+    </clipPath>
+    <use
+       id="M"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath201">
+      <use
+         xlink:href="#M"
+         id="use203" />
+    </clipPath>
+    <clipPath
+       id="clipPath205">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#M"
+         id="use207" />
+    </clipPath>
+    <use
+       id="N"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath210">
+      <use
+         xlink:href="#N"
+         id="use212" />
+    </clipPath>
+    <clipPath
+       id="clipPath214">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#N"
+         id="use216" />
+    </clipPath>
+    <use
+       id="O"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath219">
+      <use
+         xlink:href="#O"
+         id="use221" />
+    </clipPath>
+    <clipPath
+       id="clipPath223">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#O"
+         id="use225" />
+    </clipPath>
+    <clipPath
+       id="clipPath227">
+      <path
+         d="m 296,26 a 10,10 0 1 1 -20,0 10,10 0 1 1 20,0 z"
+         id="path229" />
+    </clipPath>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="40"
+       y1="280"
+       xlink:href="#Q"
+       id="P"
+       gradientTransform="matrix(.175 0 0 .175 302.79999 215.99997)" />
+    <linearGradient
+       id="Q">
+      <stop
+         stop-color="#151515"
+         id="stop233" />
+      <stop
+         offset="1"
+         stop-color="#222"
+         id="stop235" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="90"
+       y1="230"
+       xlink:href="#Q"
+       id="R"
+       gradientTransform="matrix(.375 0 0 .375 298 16)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="90"
+       y1="230"
+       xlink:href="#Q"
+       id="S"
+       gradientTransform="matrix(.25 0 0 .25 299.99999 131.99999)" />
+    <clipPath
+       id="clipPath239">
+      <rect
+         height="20"
+         rx="4"
+         y="78"
+         x="434"
+         width="20"
+         color="#bebebe"
+         id="rect241" />
+    </clipPath>
+    <clipPath
+       id="clipPath243">
+      <rect
+         height="22"
+         rx="4"
+         y="77"
+         x="433"
+         width="22"
+         color="#bebebe"
+         id="rect245" />
+    </clipPath>
+    <clipPath
+       id="clipPath247">
+      <rect
+         height="22"
+         rx="5"
+         y="77"
+         x="433"
+         width="22"
+         color="#bebebe"
+         id="rect249" />
+    </clipPath>
+    <clipPath
+       id="clipPath251">
+      <rect
+         height="30"
+         rx="6"
+         y="29"
+         x="433"
+         width="30"
+         color="#bebebe"
+         id="rect253" />
+    </clipPath>
+    <clipPath
+       id="clipPath255">
+      <rect
+         transform="matrix(0 -1 1 0 0 0)"
+         height="60"
+         rx="12.5"
+         y="142"
+         x="306"
+         width="60"
+         fill="url(#S)"
+         color="#bebebe"
+         id="rect257" />
+    </clipPath>
+    <clipPath
+       id="clipPath259">
+      <rect
+         height="90"
+         rx="18.75"
+         y="31"
+         x="307"
+         width="90"
+         fill="url(#R)"
+         color="#bebebe"
+         id="rect261" />
+    </clipPath>
+    <clipPath
+       id="clipPath263">
+      <rect
+         height="30"
+         rx="4"
+         y="29"
+         x="433"
+         width="30"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect265" />
+    </clipPath>
+    <clipPath
+       id="clipPath267">
+      <rect
+         height="22"
+         rx="3"
+         y="77"
+         x="433"
+         width="22"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect269" />
+    </clipPath>
+    <clipPath
+       id="clipPath271">
+      <path
+         d="m 144,70 c -49.705627,0 -90,40.29437 -90,90 0,49.70563 40.294373,90 90,90 49.70563,0 90,-40.29437 90,-90 0,-49.70563 -40.29437,-90 -90,-90 z m 0,32.1875 c 32.03251,0 58,25.96748 58,58 0,32.03252 -25.96749,58 -58,58 -32.03251,0 -58,-25.96748 -58,-58 0,-32.03252 25.96749,-58 58,-58 z"
+         id="path273" />
+    </clipPath>
+    <clipPath
+       id="clipPath275">
+      <path
+         d="m 152,204 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         id="path277" />
+    </clipPath>
+    <clipPath
+       id="clipPath279">
+      <rect
+         height="16"
+         rx="3"
+         y="116"
+         x="432"
+         width="16"
+         color="#bebebe"
+         id="rect281" />
+    </clipPath>
+    <clipPath
+       id="clipPath283">
+      <path
+         d="m 145,215 c 33.13708,0 60,-26.86292 60,-60 0,-33.13708 -26.86292,-60 -60,-60 -33.13708,0 -60,26.86292 -60,60 0,12.50698 3.8285,24.10633 10.375,33.71875 L 89,211 111.28125,204.625 C 120.89367,211.1715 132.49302,215 145,215 z"
+         id="path285" />
+    </clipPath>
+    <clipPath
+       id="clipPath287">
+      <path
+         d="m 98.03125,23.191212 c -41.492132,1.05238 -74.84375,35.06824 -74.84375,76.812498 0,42.40687 34.405632,76.8125 76.8125,76.8125 42.40687,0 76.8125,-34.40563 76.8125,-76.8125 0,-42.406866 -34.40563,-76.812498 -76.8125,-76.812498 -0.662607,0 -1.310145,-0.0167 -1.96875,0 z M 100,50.659962 c 27.24464,0 49.34375,22.099114 49.34375,49.343748 -1e-5,27.24464 -22.09911,49.34375 -49.34375,49.34375 -27.244636,-1e-5 -49.34375,-22.09911 -49.34375,-49.34375 0,-27.244634 22.099114,-49.343748 49.34375,-49.343748 z"
+         id="path289" />
+    </clipPath>
+    <clipPath
+       id="clipPath291">
+      <rect
+         height="16"
+         rx="2"
+         y="116"
+         x="432"
+         width="16"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect293" />
+    </clipPath>
+    <clipPath
+       id="clipPath295">
+      <rect
+         height="240"
+         rx="50"
+         y="36"
+         x="24"
+         width="240"
+         fill="#986767"
+         color="#bebebe"
+         id="rect297" />
+    </clipPath>
+    <clipPath
+       id="clipPath299">
+      <rect
+         transform="rotate(90)"
+         height="42"
+         rx="9"
+         y="223"
+         x="307"
+         width="42"
+         fill="url(#P)"
+         color="#bebebe"
+         id="rect301" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#0"
+       id="T"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.210546,0,0,1.212299,-131.34805,-325.07347)"
+       y1="279.1"
+       x2="0"
+       y2="268.33" />
+    <path
+       id="U"
+       d="m 296,26 a 10,10 0 1 1 -20,0 10,10 0 1 1 20,0 z"
+       color="#000000" />
+    <linearGradient
+       xlink:href="#W"
+       id="V"
+       y1="46.752"
+       x2="0"
+       y2="-24.433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="W">
+      <stop
+         stop-color="#c7c7c7"
+         id="stop307" />
+      <stop
+         offset="1"
+         stop-color="#dedede"
+         id="stop309" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#W"
+       id="linearGradient3312"
+       gradientUnits="userSpaceOnUse"
+       y1="46.752"
+       x2="0"
+       y2="-24.433"
+       gradientTransform="matrix(0.23630483,0,0,0.18633729,-11.350379,4.8349746)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#W-1"
+       id="linearGradient3312-3"
+       gradientUnits="userSpaceOnUse"
+       y1="46.751999"
+       x2="0"
+       y2="-24.433001"
+       gradientTransform="matrix(0.23630483,0,0,0.18633729,-11.350379,4.8349746)" />
+    <linearGradient
+       id="W-1">
+      <stop
+         stop-color="#c7c7c7"
+         id="stop307-9" />
+      <stop
+         offset="1"
+         stop-color="#dedede"
+         id="stop309-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#1"
+       id="linearGradient3938"
+       x1="7.0555558"
+       y1="13.264444"
+       x2="6.7733335"
+       y2="0.28222224"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient3990"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient3992"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4001"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4008"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4013"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4015"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4022"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4024"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4031"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4036"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4460"
+       id="linearGradient3019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.10525,0,0,1.10525,-148.53723,-295.81487)"
+       y1="279.09601"
+       x2="0"
+       y2="268.32999" />
+    <linearGradient
+       id="linearGradient4460">
+      <stop
+         offset="0"
+         style="stop-color:#1d1d1d"
+         id="stop7-3" />
+      <stop
+         offset="1"
+         style="stop-color:#333"
+         id="stop9-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3798"
+       id="linearGradient3804"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3798">
+      <stop
+         style="stop-color:#654343;stop-opacity:1;"
+         offset="0"
+         id="stop3800" />
+      <stop
+         style="stop-color:#714b4b;stop-opacity:1;"
+         offset="1"
+         id="stop3802" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28222223,0,0,0.28222223,14.970031,0.21737973)"
+       y2="1"
+       x2="24"
+       y1="47"
+       x1="24"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3244"
+       xlink:href="#linearGradient3798"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(0,-1004.3622)"
+       y2="1047.36"
+       x2="0"
+       y1="1028.36"
+       gradientUnits="userSpaceOnUse"
+       id="0-8"
+       xlink:href="#1-8" />
+    <linearGradient
+       id="1-8">
+      <stop
+         stop-color="#ffffff"
+         id="stop3236" />
+      <stop
+         offset="1"
+         stop-color="#ffffff"
+         stop-opacity="0"
+         id="stop3238" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#3-9"
+       id="2-6"
+       gradientUnits="userSpaceOnUse"
+       y1="1028.36"
+       x2="0"
+       y2="1047.36"
+       gradientTransform="matrix(1,0,0,-1,0,1052.3622)" />
+    <linearGradient
+       id="3-9">
+      <stop
+         id="stop3242" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop3244" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.10525,0,0,1.10525,-134.22541,-295.81514)"
+       xlink:href="#linearGradient4460-7"
+       id="linearGradient4902"
+       y1="279.09601"
+       y2="268.32999"
+       gradientUnits="userSpaceOnUse"
+       x2="0" />
+    <linearGradient
+       id="linearGradient4460-7">
+      <stop
+         offset="0"
+         style="stop-color:#3c2828"
+         id="stop7-6" />
+      <stop
+         offset="1"
+         style="stop-color:#604040"
+         id="stop9-0" />
+    </linearGradient>
+    <linearGradient
+       y2="268.32999"
+       x2="0"
+       y1="279.09601"
+       gradientTransform="matrix(1.10525,0,0,1.10525,-134.22541,-295.81514)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3038"
+       xlink:href="#linearGradient4460-7"
+       inkscape:collect="always" />
+    <radialGradient
+       xlink:href="#0-6"
+       id="6-9"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="0-6">
+      <stop
+         stop-color="#91b0c7"
+         id="stop7-0" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop9-3" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="radialGradient3889"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3891">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3893" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3895" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="5-0"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3898">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3900" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3902" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="radialGradient3904"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3908" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3910" />
+    </linearGradient>
+    <radialGradient
+       r="10"
+       cy="24"
+       cx="-3"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3922"
+       xlink:href="#0-6"
+       inkscape:collect="always" />
+    <radialGradient
+       xlink:href="#0-7"
+       id="5-4"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="0-7">
+      <stop
+         stop-color="#91b0c7"
+         id="stop7-8" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop9-2" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="radialGradient3960"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3962">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3964" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3966" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="6-8"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3969">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3971" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3973" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="radialGradient3975"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3979" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3981" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4121-1"
+       id="radialGradient4127-8"
+       cx="6.7733335"
+       cy="5.9266667"
+       fx="6.7733335"
+       fy="5.9266667"
+       r="0.56444442"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4121-1">
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:1;"
+         offset="0"
+         id="stop4123-7" />
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:0;"
+         offset="1"
+         id="stop4125-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4073"
+       id="linearGradient4079"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Shadow"
+     sodipodi:insensitive="true">
+    <path
+       style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 25,2 C 12.297451,2 2,12.297451 2,25 2,31.367153 4.6007106,37.116628 8.78125,41.28125 12.865755,44.99361 18.29568,47.25 24.25,47.25 c 12.702549,0 23,-10.297451 23,-23 0,-5.95432 -2.25639,-11.384245 -5.96875,-15.46875 C 37.116628,4.6007105 31.367153,2 25,2 z M 41.28125,8.78125 C 45.135604,12.894061 47.5,18.418655 47.5,24.5 c 0,12.702549 -10.297451,23 -23,23 C 18.418655,47.5 12.894061,45.135604 8.78125,41.28125 12.940939,45.4251 18.664604,48 25,48 37.702549,48 48,37.702549 48,25 48,18.664604 45.4251,12.940939 41.28125,8.78125 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3978"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 41.28125,8.78125 C 44.99361,12.865755 47.25,18.29568 47.25,24.25 c 0,12.702549 -10.297451,23 -23,23 -5.95432,0 -11.384245,-2.25639 -15.46875,-5.96875 C 12.894061,45.135604 18.418655,47.5 24.5,47.5 c 12.702549,0 23,-10.297451 23,-23 0,-6.081345 -2.364396,-11.605939 -6.21875,-15.71875 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3976"
+       inkscape:connector-curvature="0" />
+    <path
+       transform="matrix(4.3274074,0,0,3.2455556,117.19278,-35.348334)"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       sodipodi:ry="2"
+       sodipodi:rx="1.5"
+       sodipodi:cy="13"
+       sodipodi:cx="-25.5"
+       id="path3952"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       sodipodi:type="arc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Base">
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:url(#linearGradient4079);fill-opacity:1.0;stroke:none"
+       id="path3942"
+       sodipodi:cx="-25.5"
+       sodipodi:cy="13"
+       sodipodi:rx="1.5"
+       sodipodi:ry="2"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       transform="matrix(4.3274075,0,0,3.2455556,117.12222,-35.418889)" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 40.03125 7.53125 C 43.74361 11.615755 46 17.04568 46 23 C 46 35.702549 35.702549 46 23 46 C 17.04568 46 11.615755 43.74361 7.53125 40.03125 C 11.709416 44.322508 17.537578 47 24 47 C 36.702549 47 47 36.702549 47 24 C 47 17.537578 44.322508 11.709416 40.03125 7.53125 z "
+       id="path4027"
+       transform="scale(0.28222223,0.28222223)" />
+    <use
+       id="use102"
+       xlink:href="#7"
+       transform="matrix(0.39511112,0,0,0.39511112,7.9586669,-2.4271114)"
+       style="opacity:0.2"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use104-7"
+       xlink:href="#7"
+       transform="matrix(0.39511112,0,0,0.39511112,7.9586669,-2.7093336)"
+       style="fill:#f9f9f9"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use108-3"
+       xlink:href="#7"
+       transform="matrix(0.31044445,0,0,0.31044445,7.7046669,-0.67733354)"
+       style="fill:#355464"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use110"
+       xlink:href="#7"
+       transform="matrix(0.22577778,0,0,0.22577778,7.4506669,1.3546665)"
+       style="fill:#566d80"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use112"
+       xlink:href="#7"
+       transform="matrix(0.16933334,0,0,0.16933334,7.2813335,2.7093332)"
+       style="fill:#355464"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use114"
+       xlink:href="#7"
+       transform="matrix(0.05644445,0,0,0.05644445,6.9426669,4.5719999)"
+       style="fill:url(#6-9)"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use116"
+       xlink:href="#7"
+       transform="matrix(0.02822222,0,0,0.02822222,6.8580002,6.6604444)"
+       style="fill:url(#radialGradient3922)"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <path
+       id="path3828"
+       d="m 6.9426668,3.5315316 c -1.67132,0 -3.3866667,1.1789382 -3.9511112,3.3894472 l 2.8398612,1.4828833 c 0.073505,0.5768881 0.5387515,1.0223604 1.11125,1.0223604 0.5724986,0 1.037745,-0.4454723 1.1112501,-1.0223604 L 10.893778,6.9209788 C 10.329334,4.7104698 8.6139869,3.5315316 6.9426668,3.5315316 z"
+       style="fill:#ae8a14;fill-opacity:0.31999996;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#f6e6b1;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       d="m 6.7733335,3.4431112 c -1.67132,0 -3.3866668,1.1789382 -3.9511112,3.3894472 l 2.8398612,1.4828833 c 0.073505,0.5768881 0.5387515,1.0223603 1.11125,1.0223603 0.5724985,0 1.037745,-0.4454722 1.11125,-1.0223603 L 10.724445,6.8325584 C 10.16,4.6220494 8.4446535,3.4431112 6.7733335,3.4431112 z"
+       id="path57"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#74a471;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       d="M 7.3400332,7.8016908 C 7.2625855,7.7010391 7.1598854,7.6182764 7.0370614,7.5584667 6.6480649,7.3690318 6.2049986,7.504461 6.0425329,7.8683159 5.8800666,8.232173 6.0620149,8.681542 6.4510115,8.8709755 6.837186,9.059035 7.2801727,8.9191319 7.44554,8.5611236 7.4467,8.5587008 7.44783,8.5559044 7.44905,8.5532594 L 8.6551323,5.8521442 C 9.0442621,6.895091 8.9047314,7.0656991 8.0618643,7.7710418 9.5754514,7.2581562 9.3207924,6.6433998 8.6268308,4.919798 8.1805167,5.9193585 7.7227607,6.944538 7.3400321,7.8016941 z"
+       id="path57-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscccccc" />
+    <path
+       sodipodi:nodetypes="ccsscccccc"
+       inkscape:connector-curvature="0"
+       id="path3830"
+       d="M 7.452922,7.8877489 C 7.3754743,7.7870972 7.2727742,7.7043346 7.1499503,7.6445249 6.7609538,7.4550898 6.3178874,7.5905191 6.1554217,7.9543739 c -0.1624663,0.3638572 0.019482,0.8132262 0.4084786,1.0026597 0.3861745,0.1880595 0.8291613,0.048156 0.9945285,-0.3098519 0.00116,-0.00242 0.00229,-0.00521 0.00351,-0.00787 L 8.7680212,5.9382023 C 9.1571509,6.9811492 9.0176202,7.1517572 8.1747531,7.8570999 9.6883402,7.3442143 9.4336812,6.7294579 8.7397196,5.0058561 8.2934055,6.0054166 7.8356495,7.0305961 7.4529209,7.8877523 z"
+       style="fill:#74a471;fill-opacity:0.36000001;fill-rule:evenodd;stroke:none" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Symbol" />
+</svg>

--- a/Numix-Circle/48x48/apps/scorched3d.svg
+++ b/Numix-Circle/48x48/apps/scorched3d.svg
@@ -1,0 +1,1440 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 13.546667 13.546667"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   sodipodi:docname="scorched3d.svg">
+  <metadata
+     id="metadata331">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview329"
+     showgrid="false"
+     inkscape:zoom="37.474204"
+     inkscape:cx="16.623256"
+     inkscape:cy="23.130131"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     inkscape:snap-to-guides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3308" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4073">
+      <stop
+         style="stop-color:#e93535;stop-opacity:1;"
+         offset="0"
+         id="stop4075" />
+      <stop
+         style="stop-color:#eb4747;stop-opacity:1;"
+         offset="1"
+         id="stop4077" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4121">
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:1;"
+         offset="0"
+         id="stop4123" />
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:0;"
+         offset="1"
+         id="stop4125" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3944">
+      <stop
+         style="stop-color:#333333;stop-opacity:1;"
+         offset="0"
+         id="stop3946" />
+      <stop
+         style="stop-color:#3d3d3d;stop-opacity:1;"
+         offset="1"
+         id="stop3948" />
+    </linearGradient>
+    <linearGradient
+       id="0">
+      <stop
+         stop-color="#198ba6"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#42c9e7"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath11">
+      <path
+         d="m 489.217,197.275 c -2.603,0 -3.953,-1.367 -3.953,-3.971 l 0,0 0,-1.034 c 0,-2.604 1.35,-3.971 3.953,-3.971 l 0,0 1.035,0 c 2.62,0 3.97,1.367 3.97,3.971 l 0,0 0,1.034 c 0,2.604 -1.35,3.971 -3.97,3.971 l 0,0 -1.035,0 z"
+         id="path13" />
+    </clipPath>
+    <linearGradient
+       id="1">
+      <stop
+         stop-color="#620000"
+         id="stop16"
+         offset="0"
+         style="stop-color:#f96963;stop-opacity:1;" />
+      <stop
+         offset="1"
+         stop-color="#dd0f0f"
+         id="stop18"
+         style="stop-color:#f96963;stop-opacity:1;" />
+    </linearGradient>
+    <clipPath
+       id="clipPath20">
+      <rect
+         y="223"
+         x="307"
+         height="42"
+         width="42"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#2)"
+         color="#bebebe"
+         rx="9"
+         id="rect22" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.175,0,0,0.175,302.79999,215.99997)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath25">
+      <rect
+         y="85"
+         x="433"
+         height="22"
+         width="22"
+         fill="url(#3)"
+         color="#bebebe"
+         rx="4"
+         id="rect27" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0875,0,0,0.0875,430.9,81.499996)"
+       y1="291.43"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath30">
+      <rect
+         width="30"
+         height="30"
+         x="433"
+         y="37"
+         fill="url(#4)"
+         color="#bebebe"
+         rx="6"
+         id="rect32" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,430.13636,32.227267)"
+       y1="291.43"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath35">
+      <rect
+         width="16"
+         height="16"
+         x="304"
+         y="212"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#5)"
+         color="#bebebe"
+         rx="3"
+         id="rect37" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06666667,0,0,0.06666667,302.4,209.33333)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath40">
+      <rect
+         y="46"
+         x="34"
+         height="220"
+         width="220"
+         fill="url(#6)"
+         color="#bebebe"
+         rx="50"
+         id="rect42" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-4)"
+       y1="280"
+       x2="0"
+       y2="40" />
+    <clipPath
+       id="clipPath45">
+      <rect
+         y="142"
+         x="290"
+         height="60"
+         width="60"
+         fill="url(#7)"
+         color="#bebebe"
+         rx="12.5"
+         id="rect47" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="7"
+       gradientUnits="userSpaceOnUse"
+       y1="204"
+       x2="0"
+       y2="140" />
+    <clipPath
+       id="clipPath50">
+      <rect
+         width="88"
+         height="88"
+         x="292"
+         y="32"
+         fill="url(#8)"
+         color="#bebebe"
+         rx="18"
+         id="rect52" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="8"
+       gradientUnits="userSpaceOnUse"
+       y1="124"
+       x2="0"
+       y2="28" />
+    <clipPath
+       id="clipPath55">
+      <rect
+         y="101"
+         x="417"
+         height="22"
+         width="22"
+         fill="url(#9)"
+         color="#bebebe"
+         rx="5"
+         id="rect57" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0875,0,0,0.0875,414.9,97.5)"
+       y1="302.86"
+       x2="0"
+       y2="28.571" />
+    <clipPath
+       id="clipPath60">
+      <rect
+         width="30"
+         height="30"
+         x="417"
+         y="53"
+         fill="url(#A)"
+         color="#bebebe"
+         rx="7"
+         id="rect62" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#1"
+       id="A"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.11931818,0,0,0.11931818,414.13636,48.22727)"
+       y1="299.81"
+       x2="0"
+       y2="31.619" />
+    <use
+       id="B"
+       opacity="0.2"
+       fill="#ffffff"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath66">
+      <use
+         xlink:href="#B"
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         id="use68" />
+    </clipPath>
+    <clipPath
+       id="clipPath70">
+      <use
+         xlink:href="#B"
+         id="use72" />
+    </clipPath>
+    <use
+       id="C"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath75">
+      <use
+         xlink:href="#C"
+         id="use77" />
+    </clipPath>
+    <clipPath
+       id="clipPath79">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#C"
+         id="use81" />
+    </clipPath>
+    <use
+       id="D"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath84">
+      <use
+         xlink:href="#D"
+         id="use86" />
+    </clipPath>
+    <clipPath
+       id="clipPath88">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#D"
+         id="use90" />
+    </clipPath>
+    <use
+       id="E"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath93">
+      <use
+         xlink:href="#E"
+         id="use95" />
+    </clipPath>
+    <clipPath
+       id="clipPath97">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#E"
+         id="use99" />
+    </clipPath>
+    <use
+       id="F"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath102">
+      <use
+         xlink:href="#F"
+         id="use104" />
+    </clipPath>
+    <clipPath
+       id="clipPath106">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#F"
+         id="use108" />
+    </clipPath>
+    <use
+       id="G"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath111">
+      <use
+         xlink:href="#G"
+         id="use113" />
+    </clipPath>
+    <clipPath
+       id="clipPath115">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#G"
+         id="use117" />
+    </clipPath>
+    <use
+       id="H"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath120">
+      <use
+         xlink:href="#H"
+         id="use122" />
+    </clipPath>
+    <clipPath
+       id="clipPath124">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#H"
+         id="use126" />
+    </clipPath>
+    <use
+       id="I"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath129">
+      <use
+         xlink:href="#I"
+         id="use131" />
+    </clipPath>
+    <clipPath
+       id="clipPath133">
+      <rect
+         y="223"
+         x="307"
+         height="42"
+         width="42"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#2)"
+         color="#bebebe"
+         rx="9"
+         id="rect135" />
+    </clipPath>
+    <clipPath
+       id="clipPath137">
+      <rect
+         y="85"
+         x="433"
+         height="22"
+         width="22"
+         fill="url(#3)"
+         color="#bebebe"
+         rx="4"
+         id="rect139" />
+    </clipPath>
+    <clipPath
+       id="clipPath141">
+      <rect
+         width="30"
+         height="30"
+         x="433"
+         y="37"
+         fill="url(#4)"
+         color="#bebebe"
+         rx="6"
+         id="rect143" />
+    </clipPath>
+    <clipPath
+       id="clipPath145">
+      <rect
+         width="16"
+         height="16"
+         x="304"
+         y="212"
+         transform="matrix(0,1,-1,0,0,0)"
+         fill="url(#5)"
+         color="#bebebe"
+         rx="3"
+         id="rect147" />
+    </clipPath>
+    <clipPath
+       id="clipPath149">
+      <rect
+         y="46"
+         x="34"
+         height="220"
+         width="220"
+         fill="url(#6)"
+         color="#bebebe"
+         rx="50"
+         id="rect151" />
+    </clipPath>
+    <clipPath
+       id="clipPath153">
+      <rect
+         y="142"
+         x="290"
+         height="60"
+         width="60"
+         fill="url(#7)"
+         color="#bebebe"
+         rx="12.5"
+         id="rect155" />
+    </clipPath>
+    <clipPath
+       id="clipPath157">
+      <rect
+         width="88"
+         height="88"
+         x="292"
+         y="32"
+         fill="url(#8)"
+         color="#bebebe"
+         rx="18"
+         id="rect159" />
+    </clipPath>
+    <clipPath
+       id="clipPath161">
+      <rect
+         y="101"
+         x="417"
+         height="22"
+         width="22"
+         fill="url(#9)"
+         color="#bebebe"
+         rx="5"
+         id="rect163" />
+    </clipPath>
+    <clipPath
+       id="clipPath165">
+      <rect
+         width="30"
+         height="30"
+         x="417"
+         y="53"
+         fill="url(#A)"
+         color="#bebebe"
+         rx="7"
+         id="rect167" />
+    </clipPath>
+    <clipPath
+       id="clipPath169">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#I"
+         id="use171" />
+    </clipPath>
+    <use
+       id="J"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath174">
+      <use
+         xlink:href="#J"
+         id="use176" />
+    </clipPath>
+    <clipPath
+       id="clipPath178">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#J"
+         id="use180" />
+    </clipPath>
+    <use
+       id="K"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath183">
+      <use
+         xlink:href="#K"
+         id="use185" />
+    </clipPath>
+    <clipPath
+       id="clipPath187">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#K"
+         id="use189" />
+    </clipPath>
+    <use
+       id="L"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath192">
+      <use
+         xlink:href="#L"
+         id="use194" />
+    </clipPath>
+    <clipPath
+       id="clipPath196">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#L"
+         id="use198" />
+    </clipPath>
+    <use
+       id="M"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath201">
+      <use
+         xlink:href="#M"
+         id="use203" />
+    </clipPath>
+    <clipPath
+       id="clipPath205">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#M"
+         id="use207" />
+    </clipPath>
+    <use
+       id="N"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath210">
+      <use
+         xlink:href="#N"
+         id="use212" />
+    </clipPath>
+    <clipPath
+       id="clipPath214">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#N"
+         id="use216" />
+    </clipPath>
+    <use
+       id="O"
+       fill="none"
+       xlink:href="#U" />
+    <clipPath
+       id="clipPath219">
+      <use
+         xlink:href="#O"
+         id="use221" />
+    </clipPath>
+    <clipPath
+       id="clipPath223">
+      <use
+         transform="matrix(8,0,0,8,-2141.5757,-54.424243)"
+         xlink:href="#O"
+         id="use225" />
+    </clipPath>
+    <clipPath
+       id="clipPath227">
+      <path
+         d="m 296,26 a 10,10 0 1 1 -20,0 10,10 0 1 1 20,0 z"
+         id="path229" />
+    </clipPath>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="40"
+       y1="280"
+       xlink:href="#Q"
+       id="P"
+       gradientTransform="matrix(.175 0 0 .175 302.79999 215.99997)" />
+    <linearGradient
+       id="Q">
+      <stop
+         stop-color="#151515"
+         id="stop233" />
+      <stop
+         offset="1"
+         stop-color="#222"
+         id="stop235" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="90"
+       y1="230"
+       xlink:href="#Q"
+       id="R"
+       gradientTransform="matrix(.375 0 0 .375 298 16)" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       x2="0"
+       y2="90"
+       y1="230"
+       xlink:href="#Q"
+       id="S"
+       gradientTransform="matrix(.25 0 0 .25 299.99999 131.99999)" />
+    <clipPath
+       id="clipPath239">
+      <rect
+         height="20"
+         rx="4"
+         y="78"
+         x="434"
+         width="20"
+         color="#bebebe"
+         id="rect241" />
+    </clipPath>
+    <clipPath
+       id="clipPath243">
+      <rect
+         height="22"
+         rx="4"
+         y="77"
+         x="433"
+         width="22"
+         color="#bebebe"
+         id="rect245" />
+    </clipPath>
+    <clipPath
+       id="clipPath247">
+      <rect
+         height="22"
+         rx="5"
+         y="77"
+         x="433"
+         width="22"
+         color="#bebebe"
+         id="rect249" />
+    </clipPath>
+    <clipPath
+       id="clipPath251">
+      <rect
+         height="30"
+         rx="6"
+         y="29"
+         x="433"
+         width="30"
+         color="#bebebe"
+         id="rect253" />
+    </clipPath>
+    <clipPath
+       id="clipPath255">
+      <rect
+         transform="matrix(0 -1 1 0 0 0)"
+         height="60"
+         rx="12.5"
+         y="142"
+         x="306"
+         width="60"
+         fill="url(#S)"
+         color="#bebebe"
+         id="rect257" />
+    </clipPath>
+    <clipPath
+       id="clipPath259">
+      <rect
+         height="90"
+         rx="18.75"
+         y="31"
+         x="307"
+         width="90"
+         fill="url(#R)"
+         color="#bebebe"
+         id="rect261" />
+    </clipPath>
+    <clipPath
+       id="clipPath263">
+      <rect
+         height="30"
+         rx="4"
+         y="29"
+         x="433"
+         width="30"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect265" />
+    </clipPath>
+    <clipPath
+       id="clipPath267">
+      <rect
+         height="22"
+         rx="3"
+         y="77"
+         x="433"
+         width="22"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect269" />
+    </clipPath>
+    <clipPath
+       id="clipPath271">
+      <path
+         d="m 144,70 c -49.705627,0 -90,40.29437 -90,90 0,49.70563 40.294373,90 90,90 49.70563,0 90,-40.29437 90,-90 0,-49.70563 -40.29437,-90 -90,-90 z m 0,32.1875 c 32.03251,0 58,25.96748 58,58 0,32.03252 -25.96749,58 -58,58 -32.03251,0 -58,-25.96748 -58,-58 0,-32.03252 25.96749,-58 58,-58 z"
+         id="path273" />
+    </clipPath>
+    <clipPath
+       id="clipPath275">
+      <path
+         d="m 152,204 a 8,8 0 1 1 -16,0 8,8 0 1 1 16,0 z"
+         id="path277" />
+    </clipPath>
+    <clipPath
+       id="clipPath279">
+      <rect
+         height="16"
+         rx="3"
+         y="116"
+         x="432"
+         width="16"
+         color="#bebebe"
+         id="rect281" />
+    </clipPath>
+    <clipPath
+       id="clipPath283">
+      <path
+         d="m 145,215 c 33.13708,0 60,-26.86292 60,-60 0,-33.13708 -26.86292,-60 -60,-60 -33.13708,0 -60,26.86292 -60,60 0,12.50698 3.8285,24.10633 10.375,33.71875 L 89,211 111.28125,204.625 C 120.89367,211.1715 132.49302,215 145,215 z"
+         id="path285" />
+    </clipPath>
+    <clipPath
+       id="clipPath287">
+      <path
+         d="m 98.03125,23.191212 c -41.492132,1.05238 -74.84375,35.06824 -74.84375,76.812498 0,42.40687 34.405632,76.8125 76.8125,76.8125 42.40687,0 76.8125,-34.40563 76.8125,-76.8125 0,-42.406866 -34.40563,-76.812498 -76.8125,-76.812498 -0.662607,0 -1.310145,-0.0167 -1.96875,0 z M 100,50.659962 c 27.24464,0 49.34375,22.099114 49.34375,49.343748 -1e-5,27.24464 -22.09911,49.34375 -49.34375,49.34375 -27.244636,-1e-5 -49.34375,-22.09911 -49.34375,-49.34375 0,-27.244634 22.099114,-49.343748 49.34375,-49.343748 z"
+         id="path289" />
+    </clipPath>
+    <clipPath
+       id="clipPath291">
+      <rect
+         height="16"
+         rx="2"
+         y="116"
+         x="432"
+         width="16"
+         opacity="0.2"
+         fill="#6d6d6d"
+         color="#bebebe"
+         id="rect293" />
+    </clipPath>
+    <clipPath
+       id="clipPath295">
+      <rect
+         height="240"
+         rx="50"
+         y="36"
+         x="24"
+         width="240"
+         fill="#986767"
+         color="#bebebe"
+         id="rect297" />
+    </clipPath>
+    <clipPath
+       id="clipPath299">
+      <rect
+         transform="rotate(90)"
+         height="42"
+         rx="9"
+         y="223"
+         x="307"
+         width="42"
+         fill="url(#P)"
+         color="#bebebe"
+         id="rect301" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#0"
+       id="T"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.210546,0,0,1.212299,-131.34805,-325.07347)"
+       y1="279.1"
+       x2="0"
+       y2="268.33" />
+    <path
+       id="U"
+       d="m 296,26 a 10,10 0 1 1 -20,0 10,10 0 1 1 20,0 z"
+       color="#000000" />
+    <linearGradient
+       xlink:href="#W"
+       id="V"
+       y1="46.752"
+       x2="0"
+       y2="-24.433"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="W">
+      <stop
+         stop-color="#c7c7c7"
+         id="stop307" />
+      <stop
+         offset="1"
+         stop-color="#dedede"
+         id="stop309" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#W"
+       id="linearGradient3312"
+       gradientUnits="userSpaceOnUse"
+       y1="46.752"
+       x2="0"
+       y2="-24.433"
+       gradientTransform="matrix(0.23630483,0,0,0.18633729,-11.350379,4.8349746)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#W-1"
+       id="linearGradient3312-3"
+       gradientUnits="userSpaceOnUse"
+       y1="46.751999"
+       x2="0"
+       y2="-24.433001"
+       gradientTransform="matrix(0.23630483,0,0,0.18633729,-11.350379,4.8349746)" />
+    <linearGradient
+       id="W-1">
+      <stop
+         stop-color="#c7c7c7"
+         id="stop307-9" />
+      <stop
+         offset="1"
+         stop-color="#dedede"
+         id="stop309-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#1"
+       id="linearGradient3938"
+       x1="7.0555558"
+       y1="13.264444"
+       x2="6.7733335"
+       y2="0.28222224"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient3990"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient3992"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4001"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4008"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4013"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4015"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4022"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4024"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientTransform="matrix(15.333333,0,0,11.5,414.99998,-125.5)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4031"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3944"
+       id="linearGradient4036"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4460"
+       id="linearGradient3019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.10525,0,0,1.10525,-148.53723,-295.81487)"
+       y1="279.09601"
+       x2="0"
+       y2="268.32999" />
+    <linearGradient
+       id="linearGradient4460">
+      <stop
+         offset="0"
+         style="stop-color:#1d1d1d"
+         id="stop7-3" />
+      <stop
+         offset="1"
+         style="stop-color:#333"
+         id="stop9-8" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3798"
+       id="linearGradient3804"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3798">
+      <stop
+         style="stop-color:#654343;stop-opacity:1;"
+         offset="0"
+         id="stop3800" />
+      <stop
+         style="stop-color:#714b4b;stop-opacity:1;"
+         offset="1"
+         id="stop3802" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28222223,0,0,0.28222223,14.970031,0.21737973)"
+       y2="1"
+       x2="24"
+       y1="47"
+       x1="24"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3244"
+       xlink:href="#linearGradient3798"
+       inkscape:collect="always" />
+    <linearGradient
+       gradientTransform="translate(0,-1004.3622)"
+       y2="1047.36"
+       x2="0"
+       y1="1028.36"
+       gradientUnits="userSpaceOnUse"
+       id="0-8"
+       xlink:href="#1-8" />
+    <linearGradient
+       id="1-8">
+      <stop
+         stop-color="#ffffff"
+         id="stop3236" />
+      <stop
+         offset="1"
+         stop-color="#ffffff"
+         stop-opacity="0"
+         id="stop3238" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#3-9"
+       id="2-6"
+       gradientUnits="userSpaceOnUse"
+       y1="1028.36"
+       x2="0"
+       y2="1047.36"
+       gradientTransform="matrix(1,0,0,-1,0,1052.3622)" />
+    <linearGradient
+       id="3-9">
+      <stop
+         id="stop3242" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop3244" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.10525,0,0,1.10525,-134.22541,-295.81514)"
+       xlink:href="#linearGradient4460-7"
+       id="linearGradient4902"
+       y1="279.09601"
+       y2="268.32999"
+       gradientUnits="userSpaceOnUse"
+       x2="0" />
+    <linearGradient
+       id="linearGradient4460-7">
+      <stop
+         offset="0"
+         style="stop-color:#3c2828"
+         id="stop7-6" />
+      <stop
+         offset="1"
+         style="stop-color:#604040"
+         id="stop9-0" />
+    </linearGradient>
+    <linearGradient
+       y2="268.32999"
+       x2="0"
+       y1="279.09601"
+       gradientTransform="matrix(1.10525,0,0,1.10525,-134.22541,-295.81514)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3038"
+       xlink:href="#linearGradient4460-7"
+       inkscape:collect="always" />
+    <radialGradient
+       xlink:href="#0-6"
+       id="6-9"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="0-6">
+      <stop
+         stop-color="#91b0c7"
+         id="stop7-0" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop9-3" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="radialGradient3889"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3891">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3893" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3895" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="5-0"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3898">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3900" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3902" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-6"
+       id="radialGradient3904"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3906">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3908" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3910" />
+    </linearGradient>
+    <radialGradient
+       r="10"
+       cy="24"
+       cx="-3"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3922"
+       xlink:href="#0-6"
+       inkscape:collect="always" />
+    <radialGradient
+       xlink:href="#0-7"
+       id="5-4"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="0-7">
+      <stop
+         stop-color="#91b0c7"
+         id="stop7-8" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop9-2" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="radialGradient3960"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3962">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3964" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3966" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="6-8"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3969">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3971" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3973" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#0-7"
+       id="radialGradient3975"
+       cx="-3"
+       cy="24"
+       r="10"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         stop-color="#91b0c7"
+         id="stop3979" />
+      <stop
+         offset="1"
+         stop-color="#91b0c7"
+         stop-opacity="0"
+         id="stop3981" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4121-1"
+       id="radialGradient4127-8"
+       cx="6.7733335"
+       cy="5.9266667"
+       fx="6.7733335"
+       fy="5.9266667"
+       r="0.56444442"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4121-1">
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:1;"
+         offset="0"
+         id="stop4123-7" />
+      <stop
+         style="stop-color:#91b0c7;stop-opacity:0;"
+         offset="1"
+         id="stop4125-1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4073"
+       id="linearGradient4079"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Shadow"
+     sodipodi:insensitive="true">
+    <path
+       style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 25,2 C 12.297451,2 2,12.297451 2,25 2,31.367153 4.6007106,37.116628 8.78125,41.28125 12.865755,44.99361 18.29568,47.25 24.25,47.25 c 12.702549,0 23,-10.297451 23,-23 0,-5.95432 -2.25639,-11.384245 -5.96875,-15.46875 C 37.116628,4.6007105 31.367153,2 25,2 z M 41.28125,8.78125 C 45.135604,12.894061 47.5,18.418655 47.5,24.5 c 0,12.702549 -10.297451,23 -23,23 C 18.418655,47.5 12.894061,45.135604 8.78125,41.28125 12.940939,45.4251 18.664604,48 25,48 37.702549,48 48,37.702549 48,25 48,18.664604 45.4251,12.940939 41.28125,8.78125 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3978"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 41.28125,8.78125 C 44.99361,12.865755 47.25,18.29568 47.25,24.25 c 0,12.702549 -10.297451,23 -23,23 -5.95432,0 -11.384245,-2.25639 -15.46875,-5.96875 C 12.894061,45.135604 18.418655,47.5 24.5,47.5 c 12.702549,0 23,-10.297451 23,-23 0,-6.081345 -2.364396,-11.605939 -6.21875,-15.71875 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3976"
+       inkscape:connector-curvature="0" />
+    <path
+       transform="matrix(4.3274074,0,0,3.2455556,117.19278,-35.348334)"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       sodipodi:ry="2"
+       sodipodi:rx="1.5"
+       sodipodi:cy="13"
+       sodipodi:cx="-25.5"
+       id="path3952"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       sodipodi:type="arc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Base">
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:url(#linearGradient4079);fill-opacity:1.0;stroke:none"
+       id="path3942"
+       sodipodi:cx="-25.5"
+       sodipodi:cy="13"
+       sodipodi:rx="1.5"
+       sodipodi:ry="2"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       transform="matrix(4.3274075,0,0,3.2455556,117.12222,-35.418889)" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 40.03125 7.53125 C 43.74361 11.615755 46 17.04568 46 23 C 46 35.702549 35.702549 46 23 46 C 17.04568 46 11.615755 43.74361 7.53125 40.03125 C 11.709416 44.322508 17.537578 47 24 47 C 36.702549 47 47 36.702549 47 24 C 47 17.537578 44.322508 11.709416 40.03125 7.53125 z "
+       id="path4027"
+       transform="scale(0.28222223,0.28222223)" />
+    <use
+       id="use102"
+       xlink:href="#7"
+       transform="matrix(0.39511112,0,0,0.39511112,7.9586669,-2.4271114)"
+       style="opacity:0.2"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use104-7"
+       xlink:href="#7"
+       transform="matrix(0.39511112,0,0,0.39511112,7.9586669,-2.7093336)"
+       style="fill:#f9f9f9"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use108-3"
+       xlink:href="#7"
+       transform="matrix(0.31044445,0,0,0.31044445,7.7046669,-0.67733354)"
+       style="fill:#355464"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use110"
+       xlink:href="#7"
+       transform="matrix(0.22577778,0,0,0.22577778,7.4506669,1.3546665)"
+       style="fill:#566d80"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use112"
+       xlink:href="#7"
+       transform="matrix(0.16933334,0,0,0.16933334,7.2813335,2.7093332)"
+       style="fill:#355464"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use114"
+       xlink:href="#7"
+       transform="matrix(0.05644445,0,0,0.05644445,6.9426669,4.5719999)"
+       style="fill:url(#6-9)"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+    <use
+       id="use116"
+       xlink:href="#7"
+       transform="matrix(0.02822222,0,0,0.02822222,6.8580002,6.6604444)"
+       style="fill:url(#radialGradient3922)"
+       x="0"
+       y="0"
+       width="744.09448"
+       height="1052.3622" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Symbol">
+    <path
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccsc"
+       style="fill:#000000;fill-opacity:0.29199997;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       id="path3908"
+       d="M 6.4877581,5.6479708 6.3333032,5.6418208 5.8959397,5.8732692 5.5624143,5.5249355 2.9736769,5.8590699 2.8363334,6.7759822 l 0.122806,0 0.088664,0.235629 0.1286286,0 c 0,0 0.1258546,0.2625765 0.2021809,0.4968167 -0.32123,0.1510411 -0.4000529,0.2726493 -0.3625588,0.5765306 0.1468338,0.5772159 0.8556366,1.172192 1.334434,1.3085147 0.079297,0.029391 1.1336084,0.015731 2.5502494,0.013739 2.3588981,-0.00298 2.4510055,0.00335 2.5739754,-0.036211 0.6060571,-0.095883 1.0622211,-0.7722317 1.1620601,-1.1438879 0.01753,-0.1151627 0.02454,-0.2118402 0.0068,-0.3200081 C 10.627756,7.7986865 10.538966,7.6771669 10.476349,7.6274549 10.288549,7.4802472 10.203963,7.4702187 9.7230614,7.4702187 9.5069537,7.3359851 8.9774921,6.9735494 8.9774921,6.9735494 L 6.4093519,6.9048494 6.5284966,6.6437817 6.2652159,6.3332496 6.6029869,6.0690579 6.6602133,5.9330656 8.9404456,4.3887368 9.1311618,4.3695355 9.5695921,4.0405999 9.3428104,3.7676667 8.8657555,4.0471721 8.7992143,4.2177814 z M 3.9797968,8.9165981 c 0.020766,0.077515 0.050043,0.1320678 0.088164,0.2058447 C 3.9613228,9.0504258 3.8588258,8.9781513 3.7538761,8.8981114 m 6.2676899,0.038311 C 9.9318728,9.0329905 9.8201648,9.1065426 9.6497892,9.1971608 9.7486121,9.0911824 9.7581399,9.0220208 9.7710996,8.9364219 M 5.9566838,9.1039984 c 0.048817,0.079196 0.045643,0.1335882 0.1245264,0.1940981 -0.1248997,-7.056e-4 -0.2497989,-0.00141 -0.3746986,-0.00212 0.079457,-0.051785 0.15,-0.1185632 0.1998726,-0.1921109 m 1.0176028,0.00333 c 0.055799,0.083184 0.070249,0.1379347 0.1410727,0.1874046 -0.092241,0.00138 -0.2147618,0.00285 -0.3709568,0.00371 0.070602,-0.05255 0.1312999,-0.117201 0.1783322,-0.1911088 m -1.8960793,0.00104 c 0.1043637,0.1281387 0.087705,0.1409265 0.1450653,0.1903659 -0.1252337,7.055e-4 -0.2504672,0.00141 -0.3757004,0.00212 C 4.8719059,9.2006219 4.8780325,9.1734205 4.924053,9.1085938 m 3.9401994,0.00212 c 0.040988,0.087974 0.059952,0.1215413 0.138404,0.1901704 -0.1264801,0.00345 -0.214584,0.00144 -0.3413864,0 0.085167,-0.069057 0.1230853,-0.1287938 0.1615508,-0.1902079 m -1.151686,0.1901933 c 0.069399,-0.056029 0.1133362,-0.1097602 0.1611853,-0.1936011 0.010674,5.08e-4 0.041213,0 0.041213,0 0.058167,0.1148555 0.1177406,0.1619544 0.1565597,0.1936011" />
+    <path
+       d="M 6.4172023,5.549194 6.2627477,5.543044 5.825384,5.7744924 5.4918587,5.4261586 2.9031214,5.760293 2.7657778,6.6772052 l 0.122806,0 0.088664,0.235629 0.1286286,0 c 0,0 0.1258546,0.2625767 0.2021809,0.4968169 -0.32123,0.1510409 -0.4000529,0.2726493 -0.3625587,0.5765307 0.1468337,0.5772158 0.8556365,1.1721917 1.3344339,1.3085146 0.079297,0.029391 1.1336084,0.015731 2.5502493,0.013739 2.3588983,-0.00298 2.4510058,0.00335 2.5739756,-0.03621 0.6060566,-0.095884 1.0622206,-0.7722317 1.1620606,-1.1438879 0.01753,-0.1151625 0.02455,-0.21184 0.0068,-0.3200079 C 10.557201,7.6999101 10.46841,7.5783903 10.405793,7.5286785 10.217993,7.3814705 10.133408,7.3714423 9.6525059,7.3714423 9.4363982,7.2372087 8.9069363,6.8747727 8.9069363,6.8747727 L 6.3387962,6.8060728 6.4579411,6.5450051 6.1946605,6.2344729 6.5324314,5.9702811 6.5896576,5.8342889 8.8698899,4.28996 9.0606061,4.2707588 9.4990363,3.9418232 9.2722549,3.6688899 8.7952,3.9483953 8.7286585,4.1190046 z M 3.9092412,8.8178214 c 0.020766,0.077515 0.050043,0.1320679 0.088165,0.2058447 C 3.8907672,8.9516491 3.7882703,8.8793746 3.6833205,8.7993347 m 6.2676899,0.03831 C 9.8613174,8.9342138 9.7496093,9.007766 9.5792334,9.0983842 9.6780566,8.9924058 9.6875842,8.9232438 9.7005441,8.837645 M 5.8861281,9.0052215 C 5.9349451,9.0844175 5.9317711,9.13881 6.0106544,9.1993198 5.885755,9.1986143 5.7608556,9.1979098 5.6359561,9.1971998 5.7154127,9.1454148 5.7859558,9.0786363 5.8358287,9.0050889 m 1.0176025,0.00333 c 0.055799,0.083185 0.070249,0.1379349 0.141073,0.1874048 -0.092241,0.00138 -0.2147618,0.00285 -0.3709568,0.00371 0.070602,-0.05255 0.1312999,-0.117201 0.1783323,-0.1911091 m -1.8960795,0.00104 C 5.0101639,9.1376002 4.9935052,9.1503876 5.0508655,9.199827 4.9256318,9.2005326 4.8003983,9.201237 4.6751651,9.201947 4.8013503,9.1018419 4.807477,9.0746402 4.8534974,9.0098138 m 3.9401995,0.00212 c 0.040988,0.087974 0.059952,0.1215409 0.1384038,0.1901703 -0.1264802,0.00345 -0.2145837,0.00144 -0.3413862,0 C 8.6758815,9.1330431 8.7137998,9.073307 8.7522653,9.0118929 M 7.600579,9.2020895 c 0.069399,-0.056029 0.1133365,-0.1097604 0.1611856,-0.193601 0.010674,5.08e-4 0.041213,0 0.041213,0 0.058166,0.1148551 0.1177403,0.1619543 0.1565597,0.193601"
+       id="path61"
+       inkscape:connector-curvature="0"
+       style="fill:#2a2a36;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccsc" />
+  </g>
+</svg>


### PR DESCRIPTION
**Bygfoot Football Manager**, Issue #1017 
![bygfoot](https://cloud.githubusercontent.com/assets/7050624/5076187/7bdcde44-6e99-11e4-9b51-c528847217f1.png)

**Aseprite**, Issue #1023 
![aseprite](https://cloud.githubusercontent.com/assets/7050624/5076198/91dcaa58-6e99-11e4-8b00-f746467f54e0.png)

Alternatively, a version with drop shadow:
![aseprite_](https://cloud.githubusercontent.com/assets/7050624/5076221/c42c9d9c-6e99-11e4-8ed5-c0381732b4bb.png)

**Lingot**, Issues #948 and #1050 
![lingot](https://cloud.githubusercontent.com/assets/7050624/5076235/e10dcd28-6e99-11e4-8ef8-5b2ff29b14b1.png)

**KBibTex**, Issue #1216 . Icon taken straight from the Android set:
![kbibtex](https://cloud.githubusercontent.com/assets/7050624/5076270/16f1efd2-6e9a-11e4-9129-3f005a0940fc.png)
Or a modified one:
![kbibtex_2](https://cloud.githubusercontent.com/assets/7050624/5076282/274d3ecc-6e9a-11e4-9628-f8d9ee0c1b42.png)

Scorched3D, Issue #1092 
![scorched3d](https://cloud.githubusercontent.com/assets/7050624/5076311/44064f2c-6e9a-11e4-828d-e31e9ff9d822.png)
