### PR TITLE
Icons for Stuntrally + Editor, fixes #1031

### DIFF
--- a/Numix-Circle/48x48/apps/sr-editor.svg
+++ b/Numix-Circle/48x48/apps/sr-editor.svg
@@ -14,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.48.5 r10040"
-   sodipodi:docname="sr-editor.svg">
+   sodipodi:docname="sr-editor2.svg">
   <metadata
      id="metadata331">
     <rdf:RDF>
@@ -40,13 +40,13 @@
      inkscape:window-height="713"
      id="namedview329"
      showgrid="false"
-     inkscape:zoom="8.0000004"
-     inkscape:cx="19.190947"
-     inkscape:cy="30.804624"
+     inkscape:zoom="9.368551"
+     inkscape:cx="28.500577"
+     inkscape:cy="22.670749"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer2"
+     inkscape:current-layer="layer3"
      inkscape:snap-to-guides="false">
     <inkscape:grid
        type="xygrid"
@@ -55,35 +55,13 @@
   <defs
      id="defs4">
     <linearGradient
-       id="linearGradient4051">
-      <stop
-         style="stop-color:#323232;stop-opacity:1;"
-         offset="0"
-         id="stop4053" />
-      <stop
-         style="stop-color:#282828;stop-opacity:1;"
-         offset="1"
-         id="stop4055" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4043">
-      <stop
-         style="stop-color:#ffbb00;stop-opacity:1;"
-         offset="0"
-         id="stop4045" />
-      <stop
-         style="stop-color:#ffbb00;stop-opacity:0;"
-         offset="1"
-         id="stop4047" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient4073">
       <stop
-         style="stop-color:#e93535;stop-opacity:1;"
+         style="stop-color:#ce1010;stop-opacity:1;"
          offset="0"
          id="stop4075" />
       <stop
-         style="stop-color:#eb4747;stop-opacity:1;"
+         style="stop-color:#e11111;stop-opacity:1;"
          offset="1"
          id="stop4077" />
     </linearGradient>
@@ -1322,34 +1300,35 @@
          id="stop4125-1" />
     </linearGradient>
     <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4073"
+       id="linearGradient4079"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
        id="linearGradient4064">
       <stop
-         style="stop-color:#ffe42f;stop-opacity:1;"
+         style="stop-color:#ffff00;stop-opacity:1;"
          offset="0"
          id="stop4066" />
       <stop
-         style="stop-color:#ffe11b;stop-opacity:1;"
+         style="stop-color:#f6f600;stop-opacity:1;"
          offset="1"
          id="stop4068" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4064"
-       id="linearGradient4049"
-       x1="504.17776"
-       y1="142.29898"
-       x2="503.70386"
-       y2="776.52429"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4064"
-       id="linearGradient4057"
-       x1="-25.489712"
-       y1="11.001655"
-       x2="-25.53911"
-       y2="14.99066"
-       gradientUnits="userSpaceOnUse" />
+       id="linearGradient4721"
+       x1="780.74664"
+       y1="405.07867"
+       x2="886.37714"
+       y2="512.82233"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97184719,0,0,0.97184719,23.473247,12.890002)" />
   </defs>
   <g
      inkscape:groupmode="layer"
@@ -1385,7 +1364,7 @@
      inkscape:label="Base">
     <path
        sodipodi:type="arc"
-       style="opacity:1;fill:url(#linearGradient4057);fill-opacity:1.0;stroke:none"
+       style="opacity:1;fill:url(#linearGradient4079);fill-opacity:1.0;stroke:none"
        id="path3942"
        sodipodi:cx="-25.5"
        sodipodi:cy="13"
@@ -1466,53 +1445,40 @@
      inkscape:groupmode="layer"
      id="layer3"
      inkscape:label="Symbol">
+    <rect
+       x="7.3897533"
+       y="-2.6002829"
+       width="5.2005663"
+       height="5.2005663"
+       transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)"
+       style="fill:#000000;fill-opacity:0.39215686;stroke:none"
+       id="rect5268" />
     <g
-       transform="matrix(0.98766344,0,0,0.9927469,0.39095416,0.17635843)"
-       id="g4036"
-       style="fill:#133913;fill-opacity:0.52156863">
+       id="g7152"
+       transform="matrix(0.04883251,0,0,0.04883251,-6.2071093,-37.826734)">
+      <rect
+         id="rect7150"
+         style="fill:url(#linearGradient4721);fill-opacity:1;stroke:#000000;stroke-width:2.88969612"
+         transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)"
+         height="103.67666"
+         width="103.67666"
+         y="406.02164"
+         x="781.94165" />
       <g
-         transform="translate(0.14287369,0.14009393)"
-         style="fill:#133913;fill-opacity:0.52156863"
-         id="g4038" />
-      <g
-         id="g4040"
-         style="fill:#133913;fill-opacity:0.52156863">
-        <path
-           id="path4042"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccczcc"
-           style="fill:#133913;fill-opacity:0.52156863;stroke:none"
-           d="M 5.3383693,6.627247 4.7053246,3.148198 c 0.032928,-0.041016 0.128154,-0.06983 0.1773756,-0.053758 L 5.5549439,6.5645717 C 5.7536412,6.5054367 5.8786658,6.4442935 6.0967893,6.3542577 6.1411838,6.9436908 6.2555733,7.468831 5.6176907,7.6473597 4.9798187,7.8259048 4.8261562,6.7215398 4.8261562,6.7215398 5.0353327,6.6710163 5.142478,6.6907868 5.3383693,6.627247 z" />
-        <path
-           id="path4044"
-           sodipodi:nodetypes="acassscca"
-           style="fill:#133913;fill-opacity:0.52156863"
-           inkscape:connector-curvature="0"
-           d="M 9.4750729,7.3114877 C 9.3405013,7.1565262 8.943526,7.0007446 8.943526,7.0007446 c 0,0 -0.6714292,-1.1572682 -1.2221978,-1.1346092 C 7.1928197,5.8878789 6.7457364,7.0626243 6.6385521,7.0476847 6.3872292,7.0126546 6.2080517,7.5305585 5.9149419,7.6113583 5.1167472,7.8313917 4.2662079,7.0985042 3.8864805,7.3144756 3.3438613,7.6230926 3.1188552,9.2006508 3.1188552,9.2006508 c 3.9891998,1.7771052 7.1436838,0.035278 7.1436838,0.035278 0,0 -0.3330054,-1.4011218 -0.7874661,-1.9244411 z" />
-      </g>
+         id="g7142"
+         transform="matrix(0.73482,0,0,0.73482,70.337,249.88)" />
     </g>
-    <g
-       id="g5973"
-       transform="matrix(0.98766344,0,0,0.9927469,0.12284308,-0.07764177)">
-      <g
-         id="g7700"
-         style="fill:#0f0f0f;fill-opacity:0.59607843"
-         transform="translate(0.14287369,0.14009393)" />
-      <g
-         id="g7696">
-        <path
-           d="m 5.4381942,6.6625474 -0.6329761,-3.45617 c 0.032924,-0.040746 0.1281401,-0.069371 0.1773564,-0.053404 L 5.6547453,6.6002843 C 5.8534211,6.5415382 5.9784322,6.4807971 6.196532,6.3913534 6.2409217,6.9769102 6.3552988,7.498597 5.7174853,7.6759516 5.0796825,7.8533226 4.9260366,6.7562201 4.9260366,6.7562201 5.1351904,6.7060289 5.2423241,6.7256694 5.4381942,6.6625474 z"
-           style="fill:#1a1a1a;fill-opacity:1;stroke:none"
-           sodipodi:nodetypes="ccccczcc"
-           inkscape:connector-curvature="0"
-           id="path3040" />
-        <path
-           d="M 9.4607855,7.2830593 C 9.3262139,7.1280978 8.9292386,6.9723162 8.9292386,6.9723162 c 0,0 -0.6714292,-1.1572682 -1.2221978,-1.1346092 C 7.1785323,5.8594505 6.731449,7.0341959 6.6242647,7.0192563 6.3729418,6.9842262 6.1937643,7.5021301 5.9006545,7.5829299 5.1024598,7.8029633 4.2519205,7.0700758 3.8721931,7.2860472 3.3295739,7.5946642 3.1045678,9.1722224 3.1045678,9.1722224 c 3.9891998,1.7771056 7.1436842,0.035278 7.1436842,0.035278 0,0 -0.3330058,-1.4011218 -0.7874665,-1.9244411 z"
-           inkscape:connector-curvature="0"
-           style="fill:#1a1a1a;fill-opacity:1"
-           sodipodi:nodetypes="acassscca"
-           id="path3716" />
-      </g>
-    </g>
+    <path
+       d="M 7.3095557,7.337778 6.7168891,3.9511112 c 0.032924,-0.038068 0.1201166,-0.071363 0.1693333,-0.056444 L 7.5240446,7.2813335 C 7.7227224,7.2264466 7.8449877,7.1673459 8.0630891,7.083778 8.1074793,7.6308675 8.2236253,8.1152499 7.5858063,8.2809534 6.9479973,8.4466724 6.79435,7.4216425 6.79435,7.4216425 7.0035057,7.3747488 7.1136839,7.3967531 7.3095557,7.337778 z"
+       style="fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.00712809px"
+       sodipodi:nodetypes="ccccczcc"
+       inkscape:connector-curvature="0"
+       id="path3040" />
+    <path
+       d="m 9.4758031,7.7281248 c 0,0 -0.6952364,-0.072513 -1.0289057,0.00684 C 8.256522,7.780245 8.1006888,7.9183882 7.920951,7.9957659 7.6910384,8.094744 7.305476,8.2951736 7.2162397,8.2551696 6.7891131,8.0636918 6.2554356,7.4281576 5.6900558,7.4912858 5.5157036,7.5107533 5.4463518,7.7609817 5.2829583,7.8248583 4.9504391,7.9548524 4.2137369,7.8878917 4.2137369,7.8878917 l 2.5592432,2.4882093 z"
+       inkscape:connector-curvature="0"
+       style="fill:#000000"
+       sodipodi:nodetypes="caasaaccc"
+       id="path3716" />
   </g>
 </svg>

--- a/Numix-Circle/48x48/apps/stuntrally.svg
+++ b/Numix-Circle/48x48/apps/stuntrally.svg
@@ -14,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.48.5 r10040"
-   sodipodi:docname="stuntrally.svg">
+   sodipodi:docname="stuntrally2.svg">
   <metadata
      id="metadata331">
     <rdf:RDF>
@@ -23,7 +23,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,14 +40,16 @@
      inkscape:window-height="713"
      id="namedview329"
      showgrid="false"
-     inkscape:zoom="2.8284272"
-     inkscape:cx="24.17086"
-     inkscape:cy="16.549708"
+     inkscape:zoom="18.737102"
+     inkscape:cx="35.291493"
+     inkscape:cy="23.19869"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer3"
-     inkscape:snap-to-guides="false">
+     inkscape:current-layer="layer2"
+     inkscape:snap-to-guides="false"
+     showguides="true"
+     inkscape:guide-bbox="true">
     <inkscape:grid
        type="xygrid"
        id="grid3308" />
@@ -55,35 +57,35 @@
   <defs
      id="defs4">
     <linearGradient
-       id="linearGradient4051">
+       id="linearGradient5239">
       <stop
-         style="stop-color:#323232;stop-opacity:1;"
+         style="stop-color:#060606;stop-opacity:1;"
          offset="0"
-         id="stop4053" />
+         id="stop5241" />
       <stop
-         style="stop-color:#282828;stop-opacity:1;"
+         style="stop-color:#000000;stop-opacity:1;"
          offset="1"
-         id="stop4055" />
+         id="stop5243" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4043">
+       id="linearGradient5231">
       <stop
-         style="stop-color:#ffbb00;stop-opacity:1;"
+         style="stop-color:#171005;stop-opacity:1;"
          offset="0"
-         id="stop4045" />
+         id="stop5233" />
       <stop
-         style="stop-color:#ffbb00;stop-opacity:0;"
+         style="stop-color:#0f0a03;stop-opacity:1;"
          offset="1"
-         id="stop4047" />
+         id="stop5235" />
     </linearGradient>
     <linearGradient
        id="linearGradient4073">
       <stop
-         style="stop-color:#e93535;stop-opacity:1;"
+         style="stop-color:#e11111;stop-opacity:1;"
          offset="0"
          id="stop4075" />
       <stop
-         style="stop-color:#eb4747;stop-opacity:1;"
+         style="stop-color:#cf0f0f;stop-opacity:1;"
          offset="1"
          id="stop4077" />
     </linearGradient>
@@ -1322,34 +1324,62 @@
          id="stop4125-1" />
     </linearGradient>
     <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4073"
+       id="linearGradient4079"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4064"
+       id="linearGradient4070"
+       x1="780.60583"
+       y1="404.44513"
+       x2="886.99579"
+       y2="511.39191"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
        id="linearGradient4064">
       <stop
-         style="stop-color:#ffe42f;stop-opacity:1;"
+         style="stop-color:#ffff00;stop-opacity:1;"
          offset="0"
          id="stop4066" />
       <stop
-         style="stop-color:#ffe11b;stop-opacity:1;"
+         style="stop-color:#f6f600;stop-opacity:1;"
          offset="1"
          id="stop4068" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4064"
-       id="linearGradient4049"
-       x1="504.17776"
-       y1="142.29898"
-       x2="503.70386"
-       y2="776.52429"
+       xlink:href="#linearGradient5231"
+       id="linearGradient5237"
+       x1="270.47412"
+       y1="821.12433"
+       x2="266.25876"
+       y2="977.84186"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0045108,0,0,1,-4.3330423,-0.14561551)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5239"
+       id="linearGradient5245"
+       x1="780.60583"
+       y1="404.44513"
+       x2="886.99579"
+       y2="511.39191"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4064"
-       id="linearGradient4057"
-       x1="-25.499998"
-       y1="11"
-       x2="-25.499998"
-       y2="15"
-       gradientUnits="userSpaceOnUse" />
+       xlink:href="#linearGradient5231"
+       id="linearGradient5278"
+       gradientUnits="userSpaceOnUse"
+       x1="270.47412"
+       y1="821.12433"
+       x2="266.25876"
+       y2="977.84186" />
   </defs>
   <g
      inkscape:groupmode="layer"
@@ -1385,7 +1415,7 @@
      inkscape:label="Base">
     <path
        sodipodi:type="arc"
-       style="opacity:1;fill:url(#linearGradient4057);fill-opacity:1;stroke:none"
+       style="opacity:1;fill:url(#linearGradient4079);fill-opacity:1.0;stroke:none"
        id="path3942"
        sodipodi:cx="-25.5"
        sodipodi:cy="13"
@@ -1466,17 +1496,42 @@
      inkscape:groupmode="layer"
      id="layer3"
      inkscape:label="Symbol">
-    <path
-       inkscape:connector-curvature="0"
-       d="m 4.5437779,8.1562256 c 0,-1.3346666 3.7710656,-0.9967665 3.708941,-1.6933333 C 8.2306066,6.179012 6.4510973,5.9390779 6.445799,4.6002255 c -0.3593052,0.00389 -1.1659522,0.2984362 -1.2117523,0.127 -0.060222,-0.1428878 1.470972,-1.5109798 1.7550558,-1.509888 0.2840843,0.00109 1.8234152,1.3597647 1.7554246,1.509888 -0.075349,0.166376 -0.8664512,-0.1183386 -1.2118588,-0.127 -0.00415,0.9506647 1.8270719,0.9548189 1.902003,1.8344445 0.00902,1.6031585 -3.3950239,1.2949098 -3.3964485,1.7497779 -0.00127,0.4091928 1.7661628,0.6778762 1.7797486,1.6566444 l 0.013589,0.6575747 -1.6574755,0 0.00679,-0.5644413 C 6.1175813,9.3825247 4.5462502,9.0532574 4.5437779,8.1562256 z"
-       style="fill:#133913;fill-opacity:0.51999996"
-       sodipodi:nodetypes="cccczsccsccccc"
-       id="path3264" />
-    <path
-       id="path7144"
-       sodipodi:nodetypes="cccczsccsccccc"
-       style="fill:#1a1a1a"
-       d="m 4.2333334,7.9586663 c 0,-1.3346666 3.9168599,-0.9967665 3.8523335,-1.6933333 C 8.0626997,5.9814527 6.2143923,5.7415186 6.208889,4.4026662 c -0.3731963,0.00389 -1.2110291,0.2984362 -1.2586,0.127 -0.06255,-0.1428878 1.5278416,-1.5109798 1.8229085,-1.509888 0.2950671,0.00109 1.8939108,1.3597647 1.8232916,1.509888 -0.078264,0.166376 -0.8999494,-0.1183386 -1.2587111,-0.127 -0.00428,0.9506647 1.8977091,0.9548189 1.975537,1.8344445 0.00935,1.6031585 -3.5262797,1.2949098 -3.5277593,1.7497779 -0.00133,0.4091928 1.8344445,0.6778762 1.8485556,1.6566444 l 0.014111,0.657578 -1.7215556,0 0.00706,-0.5644446 C 5.8679822,9.1849654 4.2359015,8.8556981 4.2333334,7.9586663 z"
-       inkscape:connector-curvature="0" />
+    <g
+       transform="matrix(0.04756725,0,0,0.04756726,5.5048955,-37.091762)"
+       id="g5266">
+      <rect
+         x="624.90552"
+         y="578.55139"
+         width="109.3308"
+         height="109.3308"
+         transform="matrix(0.7071068,0.70710676,-0.7071068,0.70710676,0,0)"
+         style="fill:#000000;fill-opacity:0.39215686;stroke:none"
+         id="rect5268" />
+      <g
+         transform="matrix(0.73482,0,0,0.73482,70.337,249.88)"
+         id="g5270" />
+    </g>
+    <g
+       id="g7152"
+       transform="matrix(0.04745774,0,0,0.04745774,-5.8416735,-36.571119)">
+      <rect
+         id="rect7150"
+         style="fill:url(#linearGradient4070);fill-opacity:1;stroke:url(#linearGradient5245);stroke-width:2.9734057"
+         transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)"
+         height="106.68"
+         width="106.68"
+         y="404.51999"
+         x="780.44" />
+      <g
+         id="g7142"
+         transform="matrix(0.73482,0,0,0.73482,70.337,249.88)">
+        <path
+           id="path7144"
+           sodipodi:nodetypes="cccccsccsccccc"
+           style="fill:url(#linearGradient5237);fill-opacity:1"
+           d="m 232.84372,932.81425 c 0.0912,-29.08124 43.64562,-23.2353 43.69944,-35.60868 -0.0538,-13.48329 -22.56991,-13.28809 -22.66007,-32.41828 -5.28333,0.0757 -17.1308,5.82249 -17.80434,1.36088 -0.3964,-3.2766 24.07733,-44.90896 29.13437,-45.01379 5.05704,-0.10483 29.56401,42.25939 28.32509,45.01379 -1.79231,3.98473 -11.91614,-1.1929 -16.99505,-1.36088 -0.18851,7.00411 22.68087,10.9269 22.66005,33.0673 1.8e-4,29.86975 -43.44349,26.06043 -43.70155,34.95966 -0.22266,7.67827 21.52436,10.92908 21.0415,32.57013 l 0,12.75 c -7.43338,0 -22.66007,0 -22.66007,0 l 0,-12.64215 c -2.5155,-12.34698 -21.26969,-14.45217 -21.03937,-32.67798 z"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
   </g>
 </svg>


### PR DESCRIPTION
Icon for **Stunt Rally**, Issue #1031 
![stuntrally](https://cloud.githubusercontent.com/assets/7050624/5172403/e32c5d50-741f-11e4-8901-c19c7e0aab13.png)

Icon for **Stunt Rally Track Editor**
![sr-editor](https://cloud.githubusercontent.com/assets/7050624/5172399/df337120-741f-11e4-8d97-f727a11528b7.png)

Alternative Icons:
![stuntrally2](https://cloud.githubusercontent.com/assets/7050624/5086570/619d6320-6f1e-11e4-8c16-f8855e5913ad.png)
![sr-editor2](https://cloud.githubusercontent.com/assets/7050624/5086572/671b6144-6f1e-11e4-9c47-9c4408fbcf4d.png)
