### PR TITLE
Add Avidemux symlink. Fixes #1026

### DIFF
--- a/Numix-Circle/48x48/apps/avidemux_icon.svg
+++ b/Numix-Circle/48x48/apps/avidemux_icon.svg
@@ -1,0 +1,1 @@
+avidemux.svg


### PR DESCRIPTION
Symlink called _avidemux_icon.svg_. Fixes #1026.
