### PR TITLE
Icon for QElectroTech. Fixes #1341

### DIFF
--- a/Numix-Circle/48x48/apps/qelectrotech.svg
+++ b/Numix-Circle/48x48/apps/qelectrotech.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -39,9 +39,9 @@
      inkscape:window-height="713"
      id="namedview63"
      showgrid="false"
-     inkscape:zoom="31.999998"
-     inkscape:cx="24.06137"
-     inkscape:cy="36.795154"
+     inkscape:zoom="11.313708"
+     inkscape:cx="29.348019"
+     inkscape:cy="23.259619"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -135,7 +135,7 @@
          sodipodi:nodetypes="ccccssssscccccccccccc"
          inkscape:connector-curvature="0"
          d="m 27.828808,17.785915 -7.660871,7.683665 m 0,-7.683665 7.660871,7.683665 m 1.710718,-3.895943 c 0,3.061434 -2.479569,5.567136 -5.541005,5.567136 -3.061435,0 -5.541005,-2.505702 -5.541005,-5.567136 0,-3.061436 2.47957,-5.519304 5.541005,-5.519304 3.061436,0 5.541005,2.457868 5.541005,5.519304 z m -6.509277,14.068683 -11.942749,0 0,-14.068683 7.209487,0 m 11.406055,0 7.206559,0 0,14.068683 -11.835098,0 m -0.215243,-3.787723 0,7.791886 m -1.721478,-6.168576 0,4.328825"
-         style="fill:none;stroke:#363636;stroke-width:1.0790602;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.49411765"
+         style="fill:none;stroke:#6e6e6e;stroke-width:1.07906020000000002;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.43137255"
          id="path3801" />
     </g>
   </g>
@@ -154,7 +154,7 @@
     </g>
   </g>
   <path
-     style="fill:#363636;fill-opacity:0.49599998;fill-rule:nonzero;stroke:none"
+     style="fill:#6e6e6e;fill-opacity:0.43137255;fill-rule:nonzero;stroke:none"
      inkscape:connector-curvature="0"
      d="m 34.4,37.5 c 0,0 0.6,-0.324 0.6,-1.996 C 35,33.891 34.4,33.5 34.4,33.5 L 19.297,33.5 15,35.504 19.297,37.5"
      id="path65"


### PR DESCRIPTION
Icon for QElectroTech, fixes Issue #1341.
![qelectrotech](https://cloud.githubusercontent.com/assets/7050624/5231826/5ed70662-7740-11e4-8ee5-e29105d25f25.png)
