### PR TITLE
Create symlinks to java.svg for OpenJDK packages in Fedora 19/20/21.

### DIFF
--- a/Numix-Circle/48x48/apps/java-1.6.0.svg
+++ b/Numix-Circle/48x48/apps/java-1.6.0.svg
@@ -1,0 +1,1 @@
+java.svg

--- a/Numix-Circle/48x48/apps/java-1.7.0.svg
+++ b/Numix-Circle/48x48/apps/java-1.7.0.svg
@@ -1,0 +1,1 @@
+java.svg

--- a/Numix-Circle/48x48/apps/java-1.8.0.svg
+++ b/Numix-Circle/48x48/apps/java-1.8.0.svg
@@ -1,0 +1,1 @@
+java.svg


### PR DESCRIPTION
 This is another hacky fix for issue #107, this time for Fedora.
