### PR TITLE
Icon for Zeal. Fixes #1310

### DIFF
--- a/Numix-Circle/48x48/apps/zeal.svg
+++ b/Numix-Circle/48x48/apps/zeal.svg
@@ -14,7 +14,7 @@
    inkscape:version="0.48.5 r10040"
    width="100%"
    height="100%"
-   sodipodi:docname="netz.svg">
+   sodipodi:docname="zeal2.svg">
   <metadata
      id="metadata89">
     <rdf:RDF>
@@ -42,9 +42,9 @@
      showgrid="false"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:zoom="8"
-     inkscape:cx="15.805391"
-     inkscape:cy="22.447028"
+     inkscape:zoom="16"
+     inkscape:cx="15.258516"
+     inkscape:cy="19.947028"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -266,6 +266,12 @@
              id="path4782"
              inkscape:connector-curvature="0"
              style="fill:#392e28;fill-opacity:1;fill-rule:evenodd;stroke:none"
+             sodipodi:nodetypes="cccccccc" />
+          <path
+             d="m 14,30 -2,0 0,6 2,0 0,-1 -1,0 0,-4 1,0"
+             id="path3035"
+             inkscape:connector-curvature="0"
+             style="fill:#50423c;fill-opacity:1;fill-rule:evenodd;stroke:none"
              sodipodi:nodetypes="cccccccc" />
         </g>
       </g>


### PR DESCRIPTION
Icon for Zeal. Issue #1310 
![zeal2](https://cloud.githubusercontent.com/assets/7050624/5380828/e5fea3d4-809b-11e4-8f87-0a12503ed7a6.png)

Maybe better without the shadow below the "Z" symbol?
