### PR TITLE
Viking Icon. Fixes #1039

### DIFF
--- a/Numix-Circle/48x48/apps/viking.svg
+++ b/Numix-Circle/48x48/apps/viking.svg
@@ -40,9 +40,9 @@
      inkscape:window-height="713"
      id="namedview329"
      showgrid="false"
-     inkscape:zoom="11.313708"
-     inkscape:cx="25.368864"
-     inkscape:cy="27.22888"
+     inkscape:zoom="1"
+     inkscape:cx="26.91566"
+     inkscape:cy="30.764414"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -70,11 +70,11 @@
     <linearGradient
        id="linearGradient4073">
       <stop
-         style="stop-color:#b6d8f2;stop-opacity:1;"
+         style="stop-color:#99c8ed;stop-opacity:1;"
          offset="0"
          id="stop4075" />
       <stop
-         style="stop-color:#c7e1f5;stop-opacity:1;"
+         style="stop-color:#aad2f0;stop-opacity:1;"
          offset="1"
          id="stop4077" />
     </linearGradient>


### PR DESCRIPTION
Icon for Viking, Issue #1039.

The pushed icon:
![viking3](https://cloud.githubusercontent.com/assets/7050624/5391624/8fde277c-811d-11e4-8722-14993d11ae42.png)

Variants:
![viking4](https://cloud.githubusercontent.com/assets/7050624/5391627/9fac00a2-811d-11e4-857e-54c2ac260c27.png)
![viking5](https://cloud.githubusercontent.com/assets/7050624/5391629/a55a6bec-811d-11e4-8f9b-aa58db3a5830.png)
