### PR TITLE
Symlinks for D-Feet and XMind

### DIFF
--- a/Numix-Circle/48x48/apps/XMind.svg
+++ b/Numix-Circle/48x48/apps/XMind.svg
@@ -1,0 +1,1 @@
+xmind.svg

--- a/Numix-Circle/48x48/apps/d-feet.svg
+++ b/Numix-Circle/48x48/apps/d-feet.svg
@@ -1,0 +1,1 @@
+d-feet-icon.svg


### PR DESCRIPTION
Added:
- A symlink _d-feet.svg_ pointing at _d-feet-icon.svg_. Fixes issue #1359.
- A symlink _XMind.svg_ pointing at _xmind.svg_. Required at least for the Arch Linux version
