### PR TITLE
Icon for MediathekView. Fixes #1035

### DIFF
--- a/Numix-Circle/48x48/apps/mediathekview.svg
+++ b/Numix-Circle/48x48/apps/mediathekview.svg
@@ -14,7 +14,7 @@
    inkscape:version="0.48.5 r10040"
    width="100%"
    height="100%"
-   sodipodi:docname="mediathekview2.svg"
+   sodipodi:docname="mediathekview_clean.svg"
    inkscape:export-filename="/home/ismael/Imágenes/icons.png"
    inkscape:export-xdpi="245"
    inkscape:export-ydpi="245">
@@ -50,9 +50,9 @@
      inkscape:snap-smooth-nodes="false"
      inkscape:snap-midpoints="false"
      inkscape:snap-grids="true"
-     inkscape:zoom="8"
-     inkscape:cx="22.465743"
-     inkscape:cy="18.00109"
+     inkscape:zoom="22.627417"
+     inkscape:cx="31.871124"
+     inkscape:cy="24.813274"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -191,106 +191,118 @@
      id="g4185">
     <g
        transform="matrix(0.97792935,-0.2089359,0.2089359,0.97792935,-3.9320899,2.7397079)"
-       id="g4063">
+       id="g4063" />
+    <g
+       id="g4172">
+      <g
+         id="g4157">
+        <g
+           id="g3103" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g3075">
+    <g
+       id="g3143">
       <path
-         style="fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         d="m 12.840029,15.999647 22.319942,0 C 36.179347,15.999647 37,16.872061 37,17.955294 l 0,0.08906 C 37,19.127586 37,20 37,20 l -26,0 c 0,0 0,-0.872061 0,-1.955294 l 0,-0.08976 c 0,-1.083235 0.820653,-1.955298 1.840029,-1.955298 z"
-         id="rect3829"
          inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ssssccsss" />
+         style="fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 15,20 -3,4 -1,0 0,11.03125 C 11,36.114483 11.824374,37 12.84375,37 l 22.3125,0 C 36.175626,37 37,36.114483 37,35.03125 L 37,24 l -4,0 3,-4 -3,0 -3,4 -3,0 3,-4 -3,0 -3,4 -3,0 3,-4 -3,0 -3,4 -3,0 3,-4 -3,0 z"
+         id="rect3826" />
+      <path
+         style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 18,20 3,0 -3,4 -3,0 z"
+         id="path3889"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path3891"
+         d="m 24,20 3,0 -3,4 -3,0 z"
+         style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 30,20 3,0 -3,4 -3,0 z"
+         id="path3893"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
       <path
          inkscape:connector-curvature="0"
          style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         d="M 12.125,16.15625 C 11.464142,16.452294 11,17.156324 11,17.96875 l 0,0.0625 0,1.96875 4,0 -2.875,-3.84375 z"
-         id="rect3829-6" />
+         d="m 11,20 0,4 1,0 3,-4 -4,0 z"
+         id="rect3826-8" />
       <path
+         inkscape:connector-curvature="0"
+         style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 36,20 -3,4 4,0 0,-4 z"
+         id="rect3826-3"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         d="m 16,27 2,0 2.5,4 2.5,-4 2,0 0,9 -2,0 0,-5.5 -2.5,4 -2.5,-4 0,5.5 -2,0 0,-9"
+         style="font-size:17.27403069000000002px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:0.11764706000000000;stroke:none;font-family:Sans;-inkscape-font-specification:drift Bold"
+         id="path4104"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccc" />
+      <path
+         sodipodi:nodetypes="ccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path3101"
+         style="font-size:17.27403069000000002px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#7d8bc7;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:drift Bold"
+         d="m 15,26 2,0 2.5,4 2.5,-4 2,0 0,9 -2,0 0,-5.5 -2.5,4 -2.5,-4 0,5.5 -2,0 0,-9" />
+      <path
+         d="m 28,27 2,6 2,-6 2,0 -3,9 -2,0 -3,-9"
+         style="font-size:17.27403069000000002px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:0.11764706000000000;stroke:none;font-family:Sans;-inkscape-font-specification:drift Bold"
+         id="path4102"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         sodipodi:nodetypes="ccccccc"
+         inkscape:connector-curvature="0"
+         id="path3103"
+         style="font-size:17.27403069000000002px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#9e6b3e;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:drift Bold"
+         d="m 27,26 2,6 2,-6 2,0 -3,9 -2,0 -3,-9" />
+      <path
+         transform="matrix(0.97792935,-0.2089359,0.2089359,0.97792935,-3.9320899,2.7397079)"
+         inkscape:connector-curvature="0"
+         style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="M 12.135136,16.152248 C 11.474278,16.448292 11,17.156324 11,17.96875 l 0,0.0625 0,1.96875 4,0 z"
+         id="rect3829-6"
+         sodipodi:nodetypes="cscccc" />
+      <path
+         transform="matrix(0.97792935,-0.2089359,0.2089359,0.97792935,-3.9320899,2.7397079)"
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="path3939"
          d="m 30,20 3,0 -3,-4 -3,0 z"
          style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
       <path
+         transform="matrix(0.97792935,-0.2089359,0.2089359,0.97792935,-3.9320899,2.7397079)"
          style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
          d="m 24,20 3,0 -3,-4 -3,0 z"
          id="path3941"
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="ccccc" />
       <path
+         transform="matrix(0.97792935,-0.2089359,0.2089359,0.97792935,-3.9320899,2.7397079)"
          sodipodi:nodetypes="ccccc"
          inkscape:connector-curvature="0"
          id="path3943"
          d="m 18,20 3,0 -3,-4 -3,0 z"
          style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
       <path
+         transform="matrix(0.97792935,-0.2089359,0.2089359,0.97792935,-3.9320899,2.7397079)"
          inkscape:connector-curvature="0"
          style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
          d="m 33,16 3,4 1,0 0,-1.96875 0,-0.0625 C 37,16.885517 36.175626,16 35.15625,16 L 33,16 z"
          id="rect3829-0" />
-    </g>
-    <g
-       id="g4172">
-      <g
-         id="g4157">
-        <path
-           style="fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 11,20 26,0 c 0,0 0,9.98624 0,15.044706 C 37,36.127939 36.179347,37 35.159971,37 L 12.840029,37 C 11.820653,37 11,36.127939 11,35.044706 11,29.696471 11,20 11,20 z"
-           id="rect3826"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccsscc" />
-        <path
-           style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,20 3,0 -3,4 -3,0 z"
-           id="path3889"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path3891"
-           d="m 24,20 3,0 -3,4 -3,0 z"
-           style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 30,20 3,0 -3,4 -3,0 z"
-           id="path3893"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 11,20 0,4 1,0 3,-4 -4,0 z"
-           id="rect3826-8" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 36,20 -3,4 4,0 0,-4 z"
-           id="rect3826-3"
-           sodipodi:nodetypes="ccccc" />
-      </g>
       <path
-         sodipodi:nodetypes="ccccccccccccc"
          inkscape:connector-curvature="0"
-         id="path4104"
-         style="font-size:17.27403069px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:0.11764706;stroke:none;font-family:Sans;-inkscape-font-specification:drift Bold"
-         d="m 16,27 2,0 2.5,4 2.5,-4 2,0 0,9 -2,0 0,-5.5 -2.5,4 -2.5,-4 0,5.5 -2,0 0,-9" />
-      <path
-         d="m 15,26 2,0 2.5,4 2.5,-4 2,0 0,9 -2,0 0,-5.5 -2.5,4 -2.5,-4 0,5.5 -2,0 0,-9"
-         style="font-size:17.27403069px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#7d8bc7;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:drift Bold"
-         id="path3101"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccc" />
-      <path
-         sodipodi:nodetypes="ccccccc"
-         inkscape:connector-curvature="0"
-         id="path4102"
-         style="font-size:17.27403069000000002px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:0.11764706;stroke:none;font-family:Sans;-inkscape-font-specification:drift Bold"
-         d="m 28,27 2,6 2,-6 2,0 -3,9 -2,0 -3,-9" />
-      <path
-         d="m 27,26 2,6 2,-6 2,0 -3,9 -2,0 -3,-9"
-         style="font-size:17.27403069px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#9e6b3e;fill-opacity:1;stroke:none;font-family:Sans;-inkscape-font-specification:drift Bold"
-         id="path3103"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccc" />
+         style="fill:#333333;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 31.68725,11.49975 -2.9375,0.625 3.78125,3.28125 2.90625,-0.625 z m -5.875,1.25 -2.9375,0.625 3.78125,3.28125 2.9375,-0.625 z m -5.875,1.25 -2.9375,0.625 3.78125,3.28125 2.9375,-0.625 z m -5.84375,1.25 -2.125,0.46875 C 11.719281,15.77175 11.504806,15.857471 11.31,16 l 3.596,3.156 2.9375,-0.625 z"
+         id="rect3829"
+         sodipodi:nodetypes="ccccccccccccccccccccc" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
Icon for MediathekView, issue #1035

The pushed icon:
![mediathekview3](https://cloud.githubusercontent.com/assets/7050624/5459952/0f052b1e-855f-11e4-9c25-fba0a0c79ffd.png)

Option:
![mediathekview](https://cloud.githubusercontent.com/assets/7050624/5459324/5cefe8c8-855a-11e4-99a3-92a8fbd77f3e.png)
