### PR TITLE
Icon for PhotoCollage. Fixes #1191

### DIFF
--- a/Numix-Circle/48x48/apps/photocollage.svg
+++ b/Numix-Circle/48x48/apps/photocollage.svg
@@ -1,0 +1,611 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="photocollage4.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/icons.png"
+   inkscape:export-xdpi="245"
+   inkscape:export-ydpi="245">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-midpoints="false"
+     inkscape:snap-grids="true"
+     inkscape:zoom="4"
+     inkscape:cx="16.696938"
+     inkscape:cy="12.585498"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3038"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4393">
+      <stop
+         style="stop-color:#846f46;stop-opacity:1;"
+         offset="0"
+         id="stop4395" />
+      <stop
+         style="stop-color:#7a6841;stop-opacity:1;"
+         offset="1"
+         id="stop4397" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4080">
+      <stop
+         id="stop4082"
+         offset="0"
+         style="stop-color:#156aa3;stop-opacity:1;" />
+      <stop
+         id="stop4084"
+         offset="1"
+         style="stop-color:#1a7cbe;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4072">
+      <stop
+         style="stop-color:#ffff00;stop-opacity:1;"
+         offset="0"
+         id="stop4074" />
+      <stop
+         style="stop-color:#ffff00;stop-opacity:0;"
+         offset="1"
+         id="stop4076" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         style="stop-color:#ef6651;stop-opacity:1;"
+         offset="0"
+         id="stop3979" />
+      <stop
+         style="stop-color:#f17b69;stop-opacity:1;"
+         offset="1"
+         id="stop3981" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3936">
+      <stop
+         id="stop3938"
+         offset="0"
+         style="stop-color:#5880ff;stop-opacity:1;" />
+      <stop
+         id="stop3940"
+         offset="1"
+         style="stop-color:#9ab2ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         style="stop-color:#3f3953;stop-opacity:1;"
+         offset="0"
+         id="stop3829" />
+      <stop
+         style="stop-color:#766b99;stop-opacity:1;"
+         offset="1"
+         id="stop3831" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3817">
+      <stop
+         id="stop3819"
+         offset="0"
+         style="stop-color:#655b85;stop-opacity:1;" />
+      <stop
+         id="stop3821"
+         offset="1"
+         style="stop-color:#3f3953;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3784">
+      <stop
+         style="stop-color:#655b85;stop-opacity:1;"
+         offset="0"
+         id="stop3786" />
+      <stop
+         style="stop-color:#3f3953;stop-opacity:1;"
+         offset="1"
+         id="stop3788" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3040">
+      <stop
+         style="stop-color:#fab766;stop-opacity:1;"
+         offset="0"
+         id="stop3042" />
+      <stop
+         style="stop-color:#f9ad52;stop-opacity:1;"
+         offset="1"
+         id="stop3044" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#333"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#3d3d3d"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-799970715">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-808101755">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3040"
+       id="linearGradient3046"
+       x1="24"
+       y1="1"
+       x2="24"
+       y2="47"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3790"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3793"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3795"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3797"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3800"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699"
+       gradientTransform="translate(46,2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3803"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699"
+       gradientTransform="translate(41,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3806"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(41,0)"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3827"
+       id="linearGradient3833"
+       x1="35.021236"
+       y1="36.603539"
+       x2="12.061947"
+       y2="11.148674"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath-283144270">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12-4">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path14-9" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-295805906">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-9">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-8" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-070777050">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3085">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3087" />
+      </g>
+    </clipPath>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3808"
+       id="radialGradient3814"
+       cx="23.00012"
+       cy="23.993263"
+       fx="23.00012"
+       fy="23.993263"
+       r="12.000658"
+       gradientTransform="matrix(1,0,0,0.99987541,0,0.0029893)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3808">
+      <stop
+         style="stop-color:#ff5858;stop-opacity:1;"
+         offset="0"
+         id="stop3810" />
+      <stop
+         style="stop-color:#ff8c8c;stop-opacity:1;"
+         offset="1"
+         id="stop3812" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4080"
+       id="radialGradient4117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2,0,0,1.3125,-3.4,-5.3701172)"
+       cx="17"
+       cy="15.734375"
+       fx="17"
+       fy="15.734375"
+       r="2.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3977"
+       id="radialGradient4119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2,0,0,1.09375,-3.4,-1.9282226)"
+       cx="17"
+       cy="15.734375"
+       fx="17"
+       fy="15.734375"
+       r="3" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4393"
+       id="radialGradient4399"
+       cx="16.652831"
+       cy="30.075977"
+       fx="16.652831"
+       fy="30.075977"
+       r="1.2092668"
+       gradientTransform="matrix(1,0,0,0.99941742,0.27219966,0.19210565)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29"
+     style="fill:#ffeeaa">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3046);fill-opacity:1" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <rect
+     ry="1.2380953"
+     rx="1"
+     y="12"
+     x="12"
+     height="26"
+     width="26"
+     id="rect4123"
+     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none" />
+  <g
+     id="g4177">
+    <rect
+       ry="1.2380953"
+       rx="1"
+       y="11"
+       x="11"
+       height="26"
+       width="26"
+       id="rect3051"
+       style="fill:#546971;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <g
+       id="g4125">
+      <g
+         id="g3840"
+         transform="matrix(0.68178719,0,0,0.69230773,8.0467251,13.153845)">
+        <path
+           d="M 21.934059,20 41,20 41,33 21.934059,33"
+           id="path3236"
+           inkscape:connector-curvature="0"
+           style="fill:#27a9de;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           sodipodi:nodetypes="cccc" />
+        <path
+           d="M 24.865933,27.222222 21.932467,30.111111 21.934059,33 30.1,33 l 0,-2.102"
+           id="path3242"
+           inkscape:connector-curvature="0"
+           style="fill:#ddb842;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           d="m 24.865933,27.222222 1.466734,2.888889 -2.933467,1.444445 0,1.444444 6.7028,0 0,-2.102"
+           id="path3244"
+           inkscape:connector-curvature="0"
+           style="fill:#fbdb52;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           sodipodi:nodetypes="cccccc" />
+        <path
+           d="m 35,24 -9,9 15,0 0,-5.445 M 35,24"
+           id="path3246"
+           inkscape:connector-curvature="0"
+           style="fill:#ddb842;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           d="M 35,24 36.5,27 35,30.398 36.781,33 41,33 41,27.555 M 35,24"
+           id="path3248"
+           inkscape:connector-curvature="0"
+           style="fill:#fbdb52;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      </g>
+      <path
+         style="fill:#79a8b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0"
+         d="m 12,23 0,13 10,0 0,-13"
+         id="path69"
+         sodipodi:nodetypes="cccc" />
+      <path
+         style="fill:#f8ddeb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0"
+         d="m 22,23 0,3.486175 C 21.421229,26.848792 21.256707,27 20.476251,27 c -1.566806,0 -2.894761,-0.86546 -3.317622,-2.058382 -0.378898,0.250039 -0.851613,0.411992 -1.373278,0.411992 -0.97897,0 -2.488034,-0.750908 -2.785351,-1.482066 -0.236971,0.06686 -0.838771,0.214528 -1,0.212785 L 12,23"
+         id="path73"
+         sodipodi:nodetypes="ccscsccc" />
+      <rect
+         style="fill:#98cdf1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="rect3868"
+         width="13"
+         height="14"
+         x="23"
+         y="12" />
+      <g
+         transform="matrix(0.42306065,0,0,0.42309478,19.346756,10.768588)"
+         id="g3127">
+        <g
+           clip-path="url(#clipPath-070777050)"
+           id="g3129">
+          <!-- color: #7ec1ee -->
+          <g
+             id="g3131">
+            <path
+               style="fill:#cf8e92;fill-opacity:0.94100001;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 22.871,27.793 -4.949,-5.949 -0.594,-6.086 7.137,-1.957 4.703,1.434 1.66,3.668 -1.293,2.477 -5.75,6.473 m -0.914,-0.059"
+               id="path3133" />
+            <path
+               style="fill:#cf362d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 11,36 26,0 0,-2 c -0.68,-3 -4.168,-6.453 -8.516,-8.234 l -2.84,2.762 -0.898,-0.598 -2.492,-0.055 -0.797,0.922 -3.02,-2.996 C 15.113,27.266 11.683,30.473 10.999,34 m 0,2"
+               id="path3135" />
+            <path
+               style="fill:#ffcdce;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 23.449,12.332 c 2.891,0 5.23,2.434 5.23,5.434 l 0,2.453 c 0,3 -2.34,5.43 -5.23,5.43 -2.887,0 -5.23,-2.43 -5.23,-5.43 l 0,-2.453 c 0,-3 2.344,-5.434 5.23,-5.434 m 0,0"
+               id="path3137" />
+            <path
+               style="fill:#ffcdce;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 27.09,24.14 c 0.563,-0.551 2,-1.707 2.16,-2.469 l -0.055,-4.371 -8.328,-3.094 -1.355,1.148 -2.246,2.922 0.551,3.297 0.293,0.844 1.695,1.719 m 7.285,0.004"
+               id="path3139" />
+            <path
+               style="fill:#d0362d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 18.15,22.434 0,-4.07 c 0.414,-1.777 2.137,-3.574 2.996,-3.551 1.465,0.184 2.488,1.48 3.363,2.738 1.102,0.938 3.855,0.996 4.574,0 0,1.52 0,3.035 0,4.555 0.816,-0.316 1.836,-1.531 2.01,-2.578 C 30.886,6.907 16.753,7.141 16.366,18.364 c 0.121,1.414 0.965,3.406 1.785,4.07 m 0,0"
+               id="path3141" />
+            <path
+               style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 23.453,27.898 3.637,-3.77 1.82,1.883 -3.637,3.77 m -1.82,-1.883"
+               id="path3143" />
+            <path
+               style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="M 19.816,24.13 23.453,27.9 21.637,29.783 18,26.017 m 1.816,-1.887"
+               id="path3145" />
+          </g>
+        </g>
+      </g>
+      <rect
+         y="12"
+         x="12"
+         height="10"
+         width="10"
+         id="rect3942"
+         style="fill:#2ac0f3;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <g
+         id="g4111"
+         transform="translate(0,1)">
+        <path
+           style="fill:#bf7646;fill-opacity:1;stroke:none"
+           d="m 16.1,19 0.3,1 1.2,0 0.3,-1 z"
+           id="path3019"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <g
+           id="g4107">
+          <path
+             style="fill:url(#radialGradient4117);fill-opacity:1;fill-rule:nonzero;stroke:none"
+             d="m 17,12 c -1.656854,0 -3,1.343146 -3,3 0,1.28475 0.814775,2.384953 1.95,2.8125 l 0.375,0.75 1.35,0 0.4875,-0.7875 C 19.239246,17.319575 20,16.242641 20,15 20,13.343146 18.656854,12 17,12 z"
+             id="path3970"
+             inkscape:connector-curvature="0" />
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:url(#radialGradient4119);fill-opacity:1;fill-rule:nonzero;stroke:none"
+             d="m 17,12 c -0.985829,0 -1.853138,0.465832 -2.4,1.2 l 4.8,0 C 18.853138,12.465832 17.985829,12 17,12 z m 2.94,2.4 -5.88,0 C 14.02004,14.595293 14,14.792893 14,15 c 0,0.201529 0.02182,0.409436 0.06,0.6 l 5.88,0 C 19.9802,15.404209 20,15.207107 20,15 20,14.792893 19.97996,14.595293 19.94,14.4 z m -0.54,2.4 -4.8,0 c 0.3405,0.446398 0.817318,0.811882 1.35,1.0125 l 0.375,0.75 1.35,0 0.4875,-0.7875 C 18.658424,17.565241 19.081593,17.228908 19.4,16.8 z"
+             id="path3970-8"
+             sodipodi:nodetypes="sccsccsccscccccccc" />
+        </g>
+      </g>
+    </g>
+  </g>
+  <path
+     style="fill:#45a345;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 17.403979,30.029975 -0.546254,0.312146 c 0.922076,1.538874 1.292656,2.758111 1.519897,3.589665 C 18.601742,34.760843 18.592378,36 18.592378,36 l 0.921353,0 c 0,0 -0.01001,-1.336546 -0.253461,-2.224286 -0.241601,-0.887741 -0.907372,-2.160667 -1.858164,-3.745739"
+     id="path71"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     style="fill:#45a345;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 14.776968,35.436324 c 0,0 0,-1.655616 0.829056,-2.484673 0.829057,-0.831554 2.48717,-0.831554 2.48717,-0.831554 0,0 0,1.658113 -0.829056,2.487171 -0.831554,0.829056 -2.48717,0.829056 -2.48717,0.829056 m 0,0"
+     id="path77" />
+  <path
+     style="fill:#45a345;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 18.366633,32.439109 c 0,0 0.385187,-1.433993 1.29228,-1.958396 C 20.568503,29.956309 22,30.338999 22,30.338999 c 0,0 -0.385188,1.433993 -1.292281,1.958396 -0.909589,0.524403 -2.341086,0.141714 -2.341086,0.141714 m 0,0"
+     id="path79" />
+  <path
+     id="path4401"
+     d="m 21.066054,34.157501 c 0,0 -1.462427,0.25693 -2.321051,-0.343557 -0.859684,-0.60274 -1.117827,-2.061855 -1.117827,-2.061855 0,0 1.46243,-0.256929 2.321051,0.343557 0.859683,0.602739 1.117827,2.061854 1.117827,2.061854 m 0,0"
+     inkscape:connector-curvature="0"
+     style="fill:#45a345;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  <path
+     style="fill:#45a345;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 17.340066,35.860636 c 0,0 1.136849,-0.955132 1.228763,-1.99886 0.09087,-1.04599 -0.860947,-2.18164 -0.860947,-2.18164 0,0 -1.136851,0.955134 -1.228763,1.99886 -0.09087,1.04599 0.860946,2.181639 0.860946,2.181639 m 0,0"
+     id="path4403" />
+  <path
+     style="fill:#efe545;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 16.828394,26.664836 c -0.858399,0 -1.550736,0.697333 -1.550736,1.558228 0,0.01435 0,0.03683 0,0.04869 -0.01436,-0.0049 -0.01935,-0.01249 -0.03933,-0.01249 -0.831554,-0.221623 -1.69245,0.273438 -1.9122,1.104992 -0.22412,0.831555 0.270942,1.69245 1.102495,1.914073 0.01435,0.0025 0.02185,-0.0025 0.03433,0 -0.0075,0.01249 -0.01249,0.01685 -0.01249,0.03434 -0.431383,0.746025 -0.163564,1.711802 0.583086,2.143811 0.746027,0.431383 1.697444,0.161066 2.126331,-0.585584 0.0049,-0.01436 0.01001,-0.02185 0.01435,-0.03184 0.01249,0.01001 0.01935,0.01685 0.03433,0.03184 0.607435,0.609931 1.582575,0.609931 2.192506,0 0.607434,-0.611804 0.607434,-1.601928 0,-2.206864 -0.01249,-0.01001 -0.02185,-0.02185 -0.03433,-0.03184 0.01249,-0.01435 0.03433,-0.01249 0.04869,-0.01685 0.743529,-0.431385 0.997615,-1.380305 0.568104,-2.126331 -0.348978,-0.599942 -1.02883,-0.868387 -1.675593,-0.729171 -0.199773,-0.624289 -0.78286,-1.087513 -1.475197,-1.087513 m -0.436379,3.048407 c 0.141714,0.0412 0.282804,0.06367 0.436379,0.06367 0.109879,0 0.221623,-0.01001 0.324631,-0.03184 0.03184,0.09489 0.07554,0.197275 0.129228,0.290295 0.07803,0.136719 0.17043,0.255958 0.277808,0.355845 -0.131725,0.07055 -0.248467,0.151078 -0.355845,0.258455 -0.114869,0.114871 -0.207263,0.241601 -0.277809,0.375823 -0.102386,-0.109878 -0.204767,-0.214755 -0.341486,-0.292792 -0.13672,-0.08054 -0.290295,-0.129228 -0.436378,-0.161066 0.07803,-0.126732 0.153575,-0.255959 0.197275,-0.40454 0.0412,-0.153575 0.05119,-0.302156 0.04869,-0.453859 m -0.0025,0"
+     id="path81" />
+  <path
+     style="fill:url(#radialGradient4399);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0"
+     d="m 17.236856,29.083764 c 0.646139,0.172928 1.028829,0.836548 0.855901,1.480191 -0.172928,0.643643 -0.836547,1.026956 -1.48019,0.853403 -0.646141,-0.17043 -1.026958,-0.83405 -0.855901,-1.48019 0.172928,-0.643643 0.836547,-1.026956 1.48019,-0.853404 m 0,0"
+     id="path83" />
+</svg>


### PR DESCRIPTION
Icon for PhotoCollage, issue #1191
![photocollage256](https://cloud.githubusercontent.com/assets/7050624/5480726/49ff4ee4-8649-11e4-8bbd-48709ab257df.png)

![photocollage32](https://cloud.githubusercontent.com/assets/7050624/5480724/3feb3ddc-8649-11e4-965c-2c6de6758297.png)
