### PR TITLE
Symlink for TrueOS

### DIFF
--- a/data.json
+++ b/data.json
@@ -3710,7 +3710,10 @@
     },
     "distributor-logo-pcbsd": {
         "linux": {
-            "root": "distributor-logo-pcbsd"
+            "root": "distributor-logo-pcbsd",
+            "symlinks": [
+                "distributor-logo-trueos"
+            ]
         }
     },
     "distributor-logo-qubes": {


### PR DESCRIPTION
PC-BSD is now [TrueOS](https://www.trueos.org/more-on-trueos/). Logo remains similar.