### PR TITLE
Icon for Fuse ZX Spectrum Emulator

### DIFF
--- a/data.json
+++ b/data.json
@@ -4643,6 +4643,11 @@
             "root": "furiusisomount"
         }
     },
+	"fuse-emulator": {
+        "linux": {
+            "root": "fuse-emulator"
+        }
+    },
     "fusion-icon": {
         "linux": {
             "root": "fusion-icon"

--- a/data.json
+++ b/data.json
@@ -4643,7 +4643,7 @@
             "root": "furiusisomount"
         }
     },
-	"fuse-emulator": {
+    "fuse-emulator": {
         "linux": {
             "root": "fuse-emulator"
         }

--- a/icons/circle/48/fuse-emulator.svg
+++ b/icons/circle/48/fuse-emulator.svg
@@ -1,192 +1,41 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 48 48"
-   id="svg2"
-   version="1.1"
-   inkscape:version="0.91 r"
-   sodipodi:docname="fuse-emulator.svg">
-  <metadata
-     id="metadata77">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1855"
-     inkscape:window-height="1056"
-     id="namedview75"
-     showgrid="false"
-     inkscape:zoom="11.313708"
-     inkscape:cx="15.448507"
-     inkscape:cy="22.578442"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4221" />
-  </sodipodi:namedview>
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient3764"
-       x1="1"
-       x2="47"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-      <stop
-         style="stop-color:#333;stop-opacity:1"
-         id="stop7" />
-      <stop
-         offset="1"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         id="stop9" />
-    </linearGradient>
-    <linearGradient
-       id="linear0"
-       gradientUnits="userSpaceOnUse"
-       x1="89.34"
-       y1="93.88"
-       x2="94.27"
-       y2="34.86"
-       gradientTransform="matrix(0.0290589,0,0,0.0604545,21.404909,24.768589)">
-      <stop
-         style="stop-color:#d6c187;stop-opacity:1"
-         id="stop12" />
-      <stop
-         offset="1"
-         style="stop-color:#ffdd5b;stop-opacity:0"
-         id="stop14" />
-    </linearGradient>
-    <linearGradient
-       id="linear1"
-       gradientUnits="userSpaceOnUse"
-       x1="89.34"
-       y1="93.88"
-       x2="94.27"
-       y2="34.86"
-       gradientTransform="matrix(0.0213498,0,0,0.0444165,22.078489,25.91912)"
-       xlink:href="#linear0" />
-    <linearGradient
-       id="linear2"
-       gradientUnits="userSpaceOnUse"
-       x1="89.34"
-       y1="93.88"
-       x2="94.27"
-       y2="34.86"
-       gradientTransform="matrix(0.0131873,0,0,0.027435,22.791692,27.13754)"
-       xlink:href="#linear0" />
-    <linearGradient
-       xlink:href="#linear0"
-       id="linearGradient3445"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.0290589,0,0,0.0604545,21.404909,24.768589)"
-       x1="89.34"
-       y1="93.88"
-       x2="94.27"
-       y2="34.86" />
-  </defs>
-  <g
-     id="g19">
-    <path
-       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
-       style="opacity:0.05"
-       id="path21" />
-    <path
-       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
-       style="opacity:0.1"
-       id="path23" />
-    <path
-       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
-       style="opacity:0.2"
-       id="path25" />
-  </g>
-  <g
-     id="g27">
-    <path
-       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
-       style="fill:url(#linearGradient3764);fill-opacity:1"
-       id="path29" />
-  </g>
-  <g
-     id="g71">
-    <path
-       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
-       style="opacity:0.1"
-       id="path73" />
-  </g>
-  <g
-     id="g4275"
-     transform="matrix(0.87508882,0.17254598,-0.35171902,0.96592553,57.608593,21.014753)"
-     style="fill:#000000;opacity:0.1">
-    <path
-       inkscape:connector-curvature="0"
-       id="path4277"
-       d="m -43.199745,2.5252404 0.0017,19.6699386 3.998599,-0.714281 0.0011,-19.6704433 -4.001424,0.7147857 z"
-       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
-    <path
-       id="path4279"
-       transform="matrix(1.4488887,-0.25881905,0.38822858,0.96592583,-274.76521,-108.463)"
-       d="m 124.15234,147.16211 -5.09179,19 2.76172,0 5.09179,-19 -2.76172,0 z"
-       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path4281"
-       d="m -32.299828,0.57815762 -0.0011,19.67044338 3.998585,-0.714279 0.0011,-19.67044543 -3.9986,0.71428105 z"
-       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
-    <path
-       inkscape:connector-curvature="0"
-       id="path4283"
-       d="m -26.851992,-0.39500461 -0.0011,19.67044561 3.998599,-0.714281 0.0011,-19.6704431 -3.998585,0.71427849 z"
-       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
-  </g>
-  <g
-     transform="matrix(0.87508882,0.17254598,-0.35171902,0.96592553,56.608593,20.014753)"
-     id="g4195-3">
-    <path
-       style="opacity:1;fill:#ff4040;fill-opacity:1;stroke:none"
-       d="m -43.199745,2.5252404 0.0017,19.6699386 3.998599,-0.714281 0.0011,-19.6704433 -4.001424,0.7147857 z"
-       id="rect4197-6"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:1;fill:#ffdb40;fill-opacity:1;stroke:none"
-       d="m 124.15234,147.16211 -5.09179,19 2.76172,0 5.09179,-19 -2.76172,0 z"
-       transform="matrix(1.4488887,-0.25881905,0.38822858,0.96592583,-274.76521,-108.463)"
-       id="rect4199-7" />
-    <path
-       style="opacity:1;fill:#6bed00;fill-opacity:1;stroke:none"
-       d="m -32.299828,0.57815762 -0.0011,19.67044338 3.998585,-0.714279 0.0011,-19.67044543 -3.9986,0.71428105 z"
-       id="rect4201-5"
-       inkscape:connector-curvature="0" />
-    <path
-       style="opacity:1;fill:#40d6ff;fill-opacity:1;stroke:none"
-       d="m -26.851992,-0.39500461 -0.0011,19.67044561 3.998599,-0.714281 0.0011,-19.6704431 -3.998585,0.71427849 z"
-       id="rect4203-3"
-       inkscape:connector-curvature="0" />
-  </g>
+<svg id="svg2" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48" xmlns:dc="http://purl.org/dc/elements/1.1/">
+ <metadata id="metadata77">
+  <rdf:RDF>
+   <cc:Work rdf:about="">
+    <dc:format>image/svg+xml</dc:format>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:title/>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs id="defs4">
+  <linearGradient id="linearGradient3764" x2="47" gradientUnits="userSpaceOnUse" x1="1" gradientTransform="matrix(0 -1 1 0 -.0000015 48)">
+   <stop id="stop7" stop-color="#333" offset="0"/>
+   <stop id="stop9" stop-color="#3d3d3d" offset="1"/>
+  </linearGradient>
+ </defs>
+ <g id="g19">
+  <path id="path21" opacity=".05" d="m36.31 5c5.859 4.062 9.688 10.831 9.688 18.5 0 12.426-10.07 22.5-22.5 22.5-7.669 0-14.438-3.828-18.5-9.688 1.037 1.822 2.306 3.499 3.781 4.969 4.085 3.712 9.514 5.969 15.469 5.969 12.703 0 23-10.298 23-23 0-5.954-2.256-11.384-5.969-15.469-1.469-1.475-3.147-2.744-4.969-3.781zm4.969 3.781c3.854 4.113 6.219 9.637 6.219 15.719 0 12.703-10.297 23-23 23-6.081 0-11.606-2.364-15.719-6.219 4.16 4.144 9.883 6.719 16.219 6.719 12.703 0 23-10.298 23-23 0-6.335-2.575-12.06-6.719-16.219z"/>
+  <path id="path23" opacity=".1" d="m41.28 8.781c3.712 4.085 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.113 3.854 9.637 6.219 15.719 6.219 12.703 0 23-10.298 23-23 0-6.081-2.364-11.606-6.219-15.719z"/>
+  <path id="path25" opacity=".2" d="m31.25 2.375c8.615 3.154 14.75 11.417 14.75 21.13 0 12.426-10.07 22.5-22.5 22.5-9.708 0-17.971-6.135-21.12-14.75a23 23 0 0 0 44.875 -7 23 23 0 0 0 -16 -21.875z"/>
+ </g>
+ <g id="g27">
+  <path id="path29" fill="url(#linearGradient3764)" d="m24 1c12.703 0 23 10.297 23 23s-10.297 23-23 23-23-10.297-23-23 10.297-23 23-23z"/>
+ </g>
+ <g id="g71">
+  <path id="path73" opacity=".1" d="m40.03 7.531c3.712 4.084 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.178 4.291 10.01 6.969 16.469 6.969 12.703 0 23-10.298 23-23 0-6.462-2.677-12.291-6.969-16.469z"/>
+ </g>
+ <g id="g4275" opacity=".1" transform="matrix(.87509 .17255 -.35172 .96593 57.609 21.015)">
+  <path id="path4277" opacity="1" d="m-43.2 2.5252 0.0017 19.67 3.9986-0.71428 0.0011-19.67-4.0014 0.71479z"/>
+  <path id="path4279" opacity="1" d="m124.15 147.16-5.0918 19h2.7617l5.0918-19h-2.7617z" transform="matrix(1.4489 -.25882 .38823 .96593 -274.77 -108.46)"/>
+  <path id="path4281" opacity="1" d="m-32.3 0.57816-0.0011 19.67 3.9986-0.71428 0.0011-19.67-3.9986 0.71428z"/>
+  <path id="path4283" opacity="1" d="m-26.852-0.395-0.0011 19.67 3.9986-0.71428 0.0011-19.67-3.9986 0.71428z"/>
+ </g>
+ <g id="g4195-3" transform="matrix(.87509 .17255 -.35172 .96593 56.609 20.015)">
+  <path id="rect4197-6" d="m-43.2 2.5252 0.0017 19.67 3.9986-0.71428 0.0011-19.67-4.0014 0.71479z" fill="#ff4040"/>
+  <path id="rect4199-7" d="m124.15 147.16-5.0918 19h2.7617l5.0918-19h-2.7617z" transform="matrix(1.4489 -.25882 .38823 .96593 -274.77 -108.46)" fill="#ffdb40"/>
+  <path id="rect4201-5" d="m-32.3 0.57816-0.0011 19.67 3.9986-0.71428 0.0011-19.67-3.9986 0.71428z" fill="#6bed00"/>
+  <path id="rect4203-3" d="m-26.852-0.395-0.0011 19.67 3.9986-0.71428 0.0011-19.67-3.9986 0.71428z" fill="#40d6ff"/>
+ </g>
 </svg>

--- a/icons/circle/48/fuse-emulator.svg
+++ b/icons/circle/48/fuse-emulator.svg
@@ -11,7 +11,7 @@
    viewBox="0 0 48 48"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="0.91 r"
    sodipodi:docname="fuse-emulator.svg">
   <metadata
      id="metadata77">
@@ -21,6 +21,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -33,13 +34,13 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1215"
-     inkscape:window-height="1000"
+     inkscape:window-width="1855"
+     inkscape:window-height="1056"
      id="namedview75"
      showgrid="false"
-     inkscape:zoom="16"
-     inkscape:cx="21.491117"
-     inkscape:cy="27.48933"
+     inkscape:zoom="11.313708"
+     inkscape:cx="15.448507"
+     inkscape:cy="22.578442"
      inkscape:window-x="65"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -137,24 +138,55 @@
        style="opacity:0.1"
        id="path73" />
   </g>
-  <path
-     style="opacity:1;fill:#ff4040;fill-opacity:1;stroke:none"
-     d="M 41.548828 9.1699219 L 9.1542969 41.564453 A 23 23 0 0 0 11.787109 43.457031 L 43.46875 11.775391 A 23 23 0 0 0 41.548828 9.1699219 z "
-     id="rect4223" />
-  <path
-     style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
-     d="M 45.800781 20.195312 L 20.1875 45.806641 A 23 23 0 0 0 23 46 A 23 23 0 0 0 24.576172 45.945312 L 45.919922 24.601562 A 23 23 0 0 0 46 23 A 23 23 0 0 0 45.800781 20.195312 z "
-     id="path4248" />
-  <path
-     style="opacity:1;fill:#ffdb40;fill-opacity:1;stroke:none"
-     d="M 43.433594 11.710938 L 11.726562 43.417969 A 23 23 0 0 0 14.667969 45.001953 L 44.994141 14.675781 A 23 23 0 0 0 43.433594 11.710938 z "
-     id="rect4225" />
-  <path
-     style="opacity:1;fill:#6bed00;fill-opacity:1;stroke:none"
-     d="M 44.962891 14.607422 L 14.599609 44.970703 A 23 23 0 0 0 17.935547 46.160156 L 46.177734 17.917969 A 23 23 0 0 0 44.962891 14.607422 z "
-     id="rect4227" />
-  <path
-     style="opacity:1;fill:#40d6ff;fill-opacity:1;stroke:none"
-     d="M 46.158203 17.837891 L 17.855469 46.138672 A 23 23 0 0 0 21.644531 46.876953 L 46.857422 21.664062 A 23 23 0 0 0 46.158203 17.837891 z "
-     id="rect4229" />
+  <g
+     id="g4275"
+     transform="matrix(0.87508882,0.17254598,-0.35171902,0.96592553,57.608593,21.014753)"
+     style="fill:#000000;opacity:0.1">
+    <path
+       inkscape:connector-curvature="0"
+       id="path4277"
+       d="m -43.199745,2.5252404 0.0017,19.6699386 3.998599,-0.714281 0.0011,-19.6704433 -4.001424,0.7147857 z"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+    <path
+       id="path4279"
+       transform="matrix(1.4488887,-0.25881905,0.38822858,0.96592583,-274.76521,-108.463)"
+       d="m 124.15234,147.16211 -5.09179,19 2.76172,0 5.09179,-19 -2.76172,0 z"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4281"
+       d="m -32.299828,0.57815762 -0.0011,19.67044338 3.998585,-0.714279 0.0011,-19.67044543 -3.9986,0.71428105 z"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4283"
+       d="m -26.851992,-0.39500461 -0.0011,19.67044561 3.998599,-0.714281 0.0011,-19.6704431 -3.998585,0.71427849 z"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     transform="matrix(0.87508882,0.17254598,-0.35171902,0.96592553,56.608593,20.014753)"
+     id="g4195-3">
+    <path
+       style="opacity:1;fill:#ff4040;fill-opacity:1;stroke:none"
+       d="m -43.199745,2.5252404 0.0017,19.6699386 3.998599,-0.714281 0.0011,-19.6704433 -4.001424,0.7147857 z"
+       id="rect4197-6"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#ffdb40;fill-opacity:1;stroke:none"
+       d="m 124.15234,147.16211 -5.09179,19 2.76172,0 5.09179,-19 -2.76172,0 z"
+       transform="matrix(1.4488887,-0.25881905,0.38822858,0.96592583,-274.76521,-108.463)"
+       id="rect4199-7" />
+    <path
+       style="opacity:1;fill:#6bed00;fill-opacity:1;stroke:none"
+       d="m -32.299828,0.57815762 -0.0011,19.67044338 3.998585,-0.714279 0.0011,-19.67044543 -3.9986,0.71428105 z"
+       id="rect4201-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#40d6ff;fill-opacity:1;stroke:none"
+       d="m -26.851992,-0.39500461 -0.0011,19.67044561 3.998599,-0.714281 0.0011,-19.6704431 -3.998585,0.71427849 z"
+       id="rect4203-3"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/icons/circle/48/fuse-emulator.svg
+++ b/icons/circle/48/fuse-emulator.svg
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="fuse-emulator.svg">
+  <metadata
+     id="metadata77">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="1000"
+     id="namedview75"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="21.491117"
+     inkscape:cy="27.48933"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4221" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         style="stop-color:#333;stop-opacity:1"
+         id="stop7" />
+      <stop
+         offset="1"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       id="linear0"
+       gradientUnits="userSpaceOnUse"
+       x1="89.34"
+       y1="93.88"
+       x2="94.27"
+       y2="34.86"
+       gradientTransform="matrix(0.0290589,0,0,0.0604545,21.404909,24.768589)">
+      <stop
+         style="stop-color:#d6c187;stop-opacity:1"
+         id="stop12" />
+      <stop
+         offset="1"
+         style="stop-color:#ffdd5b;stop-opacity:0"
+         id="stop14" />
+    </linearGradient>
+    <linearGradient
+       id="linear1"
+       gradientUnits="userSpaceOnUse"
+       x1="89.34"
+       y1="93.88"
+       x2="94.27"
+       y2="34.86"
+       gradientTransform="matrix(0.0213498,0,0,0.0444165,22.078489,25.91912)"
+       xlink:href="#linear0" />
+    <linearGradient
+       id="linear2"
+       gradientUnits="userSpaceOnUse"
+       x1="89.34"
+       y1="93.88"
+       x2="94.27"
+       y2="34.86"
+       gradientTransform="matrix(0.0131873,0,0,0.027435,22.791692,27.13754)"
+       xlink:href="#linear0" />
+    <linearGradient
+       xlink:href="#linear0"
+       id="linearGradient3445"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0290589,0,0,0.0604545,21.404909,24.768589)"
+       x1="89.34"
+       y1="93.88"
+       x2="94.27"
+       y2="34.86" />
+  </defs>
+  <g
+     id="g19">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       style="opacity:0.05"
+       id="path21" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       style="opacity:0.1"
+       id="path23" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       style="opacity:0.2"
+       id="path25" />
+  </g>
+  <g
+     id="g27">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       style="fill:url(#linearGradient3764);fill-opacity:1"
+       id="path29" />
+  </g>
+  <g
+     id="g71">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       style="opacity:0.1"
+       id="path73" />
+  </g>
+  <path
+     style="opacity:1;fill:#ff4040;fill-opacity:1;stroke:none"
+     d="M 41.548828 9.1699219 L 9.1542969 41.564453 A 23 23 0 0 0 11.787109 43.457031 L 43.46875 11.775391 A 23 23 0 0 0 41.548828 9.1699219 z "
+     id="rect4223" />
+  <path
+     style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+     d="M 45.800781 20.195312 L 20.1875 45.806641 A 23 23 0 0 0 23 46 A 23 23 0 0 0 24.576172 45.945312 L 45.919922 24.601562 A 23 23 0 0 0 46 23 A 23 23 0 0 0 45.800781 20.195312 z "
+     id="path4248" />
+  <path
+     style="opacity:1;fill:#ffdb40;fill-opacity:1;stroke:none"
+     d="M 43.433594 11.710938 L 11.726562 43.417969 A 23 23 0 0 0 14.667969 45.001953 L 44.994141 14.675781 A 23 23 0 0 0 43.433594 11.710938 z "
+     id="rect4225" />
+  <path
+     style="opacity:1;fill:#6bed00;fill-opacity:1;stroke:none"
+     d="M 44.962891 14.607422 L 14.599609 44.970703 A 23 23 0 0 0 17.935547 46.160156 L 46.177734 17.917969 A 23 23 0 0 0 44.962891 14.607422 z "
+     id="rect4227" />
+  <path
+     style="opacity:1;fill:#40d6ff;fill-opacity:1;stroke:none"
+     d="M 46.158203 17.837891 L 17.855469 46.138672 A 23 23 0 0 0 21.644531 46.876953 L 46.857422 21.664062 A 23 23 0 0 0 46.158203 17.837891 z "
+     id="rect4229" />
+</svg>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/6173262/20034611/01366874-a3c4-11e6-903e-0163521cbc0e.png)

Icon for Fuse Emulator as requested in https://github.com/numixproject/numix-core/issues/3315.
I'm not sure if shadow located under the rainbow is necessary.