### PR TITLE
fix pep8, rewrite some codes

### DIFF
--- a/gen.py
+++ b/gen.py
@@ -15,9 +15,9 @@ from json import load
 from os import listdir, makedirs, path, symlink
 from shutil import copy2, rmtree
 from subprocess import PIPE, Popen, call
-from gi import require_version
-require_version('Rsvg', '2.0')
 try:
+    from gi import require_version
+    require_version('Rsvg', '2.0')
     from gi.repository import Rsvg
     from cairo import ImageSurface, Context, FORMAT_ARGB32
     use_inkscape = False

--- a/gen.py
+++ b/gen.py
@@ -125,7 +125,11 @@ else:
 
 
 # Only certain icon sizes may be covered
-sizes = listdir(path.join("icons", theme))
+try:
+    sizes = listdir(path.join("icons", theme))
+except FileNotFoundError:
+    exit("The theme {0} does not exists.Please reclone" 
+        "the repository and try again.".format(theme))
 
 
 # The Generation Stuff

--- a/gen.py
+++ b/gen.py
@@ -1,32 +1,89 @@
 #!/usr/bin/python3
-
-# Copyright (C) 2016
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License (version 3+) as
-# published by the Free Software Foundation. You should have received
-# a copy of the GNU General Public License along with this program.
-# If not, see <http://www.gnu.org/licenses/>.
-
+# pylint: disable=C0103
+"""
+Copyright (C) 2016
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License (version 3+) as
+published by the Free Software Foundation. You should have received
+a copy of the GNU General Public License along with this program.
+If not, see <http://www.gnu.org/licenses/>.
+"""
 # Sorting out modules
 from argparse import ArgumentParser
 from io import BytesIO
 from json import load
 from os import listdir, makedirs, path, symlink
-from shutil import copy2, move, rmtree
+from shutil import copy2, rmtree
 from subprocess import PIPE, Popen, call
-
 from gi import require_version
 require_version('Rsvg', '2.0')
 try:
     from gi.repository import Rsvg
-    import cairo
+    from cairo import ImageSurface, Context, FORMAT_ARGB32
     use_inkscape = False
-except (ImportError, AttributeError):
+except (ImportError, AttributeError, ValueError):
     ink_flag = call(['which', 'inkscape'], stdout=PIPE, stderr=PIPE)
     if ink_flag == 0:
         use_inkscape = True
     else:
         exit("Can't load cariosvg nor inkscape")
+
+
+class PNG2IcnsNotInstalled(Exception):
+    """Exception raised when png2icns is not installed."""
+
+    def __init__(self):
+        super(PNG2IcnsNotInstalled, self).__init__()
+
+
+def mkdir(base_directory, sub_dirs=None):
+    """Create a directory and subdirs."""
+    try:
+        if not sub_dirs:
+            makedirs(base_directory)
+        else:
+            for sub_directory in sub_dirs:
+                makedirs(path.join(base_directory, sub_directory))
+    except FileExistsError:
+        answer = input("The theme already exists."
+                       "Would you like to rebuild it again? "
+                       "Y[es], N[o]").strip().lower()
+        if answer in ["y", "yes"]:
+            rmtree(base_directory)
+            mkdir(base_directory, sub_dirs)
+        else:
+            exit()
+
+
+def convert_svg2png(infile, outfile, width, height):
+    """
+    Convert svg files to png using Cairosvg or Inkscape.
+
+    @file_path : String; the svg file absolute path
+    @dest_path : String; the png file absolute path
+    """
+    if use_inkscape:
+        cmd = ["inkscape", "-z", "-f", infile, "-e", outfile,
+               "-w", str(width), "-h", str(height)]
+        Popen(cmd, stdout=PIPE, stderr=PIPE).communicate()
+    else:
+        handle = Rsvg.Handle()
+        svg = handle.new_from_file(infile)
+        dim = svg.get_dimensions()
+
+        img = ImageSurface(FORMAT_ARGB32, width, height)
+        ctx = Context(img)
+        ctx.scale(width / dim.width, height / dim.height)
+        svg.render_cairo(ctx)
+
+        png_io = BytesIO()
+        img.write_to_png(png_io)
+        with open(outfile, 'wb') as fout:
+            fout.write(png_io.getvalue())
+        fout.close()
+        svg.close()
+        png_io.close()
+        img.finish()
 
 
 parser = ArgumentParser(prog="Numix-core")
@@ -67,101 +124,75 @@ else:
     platform = args.platform
 
 
-def mkdir(dir):
-    if not path.exists(dir):
-        makedirs(dir)
-
-
-def convert_svg2png(infile, outfile, w, h):
-    """
-        Converts svg files to png using Cairosvg or Inkscape
-        @file_path : String; the svg file absolute path
-        @dest_path : String; the png file absolute path
-    """
-    if use_inkscape:
-        p = Popen(["inkscape", "-z", "-f", infile, "-e", outfile,
-                   "-w", str(w), "-h", str(h)],
-                  stdout=PIPE, stderr=PIPE)
-        output, err = p.communicate()
-    else:
-        handle = Rsvg.Handle()
-        svg = handle.new_from_file(infile)
-        dim = svg.get_dimensions()
-
-        img = cairo.ImageSurface(cairo.FORMAT_ARGB32, w, h)
-        ctx = cairo.Context(img)
-        ctx.scale(w / dim.width, h / dim.height)
-        svg.render_cairo(ctx)
-
-        png_io = BytesIO()
-        img.write_to_png(png_io)
-        with open(outfile, 'wb') as fout:
-            fout.write(png_io.getvalue())
-        svg.close()
-        png_io.close()
-        img.finish()
-
-
 # Only certain icon sizes may be covered
-sizes = listdir("icons/" + theme)
+sizes = listdir(path.join("icons", theme))
 
 
 # The Generation Stuff
 if platform == "android":
     print("\nGenerating Android theme...")
-    adir = "com.numix.icons_{0}/".format(theme)
-    adir_extra = "MainActivity22/app/src/main/res/drawable-xxhdpi/"
-    adir = adir + adir_extra
-    mkdir(adir)
+    android_dir = path.join("MainActivity22", "app", "src", "main", "res",
+                            "drawable-xxhdpi", "com.numix.icons_{0}".format(theme))
+    mkdir(android_dir)
     for icon in icons:
         for name in icons[icon].get("android", []):
             name = name.replace("_", ".")
-            if path.exists("icons/" + theme + "/48/" + icon + ".svg"):
-                convert_svg2png("icons/" + theme + "/48/" + icon + ".svg",
-                                adir + name + ".png", 192, 192)
+            input_icon = path.join("icons", theme, "48",
+                                   "{0}.svg".format(icon))
+            output_icon = path.join(android_dir, "{0}.png".format(name))
+            if path.exists(input_icon):
+                convert_svg2png(input_icon, output_icon, 192, 192)
 elif platform == "linux":
     print("\nGenerating Linux theme...")
-    ldir = "numix-icon-theme-{0}/Numix-{1}/".format(theme, theme.title())
-    for size in sizes:
-        mkdir(ldir + size + "/apps")
+    linux_dir = path.join(
+        "numix-icon-theme-{0}".format(theme), "Numix-{0}".format(theme.title()), "")
+    mkdir(linux_dir, [path.join(size, "apps") for size in sizes])
     for icon in icons:
         if "linux" in icons[icon].keys():
             for size in sizes:
-                root = icons[icon]["linux"]["root"] + ".svg"
-                if path.exists("icons/" + theme + "/" + size + "/" + icon + ".svg"):
+                root_icon = "{0}.svg".format(icons[icon]["linux"]["root"])
+                input_icon = path.join(
+                    "icons", theme, size, "{0}.svg".format(icon))
+                output_vector = path.join(linux_dir, size, "apps", root_icon)
+                if path.exists(input_icon):
                     if "bfb" in icons[icon]["linux"].keys():
+                        bfb_icon = "{0}.png".format(
+                            icons[icon]["linux"]["bfb"])
+                        output_bfb = path.join(
+                            linux_dir, size, "apps", bfb_icon)
                         if int(size) == 48:
-                            convert_svg2png("icons/" + theme + "/" + size + "/" +
-                                            icon + ".svg", ldir + size + "/apps/" + icons[icon]["linux"]["bfb"] + ".png", 144, 144)
-                    copy2("icons/" + theme + "/" + size + "/" + icon + ".svg",
-                          ldir + size + "/apps/" + root)
+                            convert_svg2png(input_icon, output_bfb, 144, 144)
+                    copy2(input_icon, output_vector)
                     for link in icons[icon]["linux"].get("symlinks", []):
+                        link_path = path.join(
+                            linux_dir, size, "apps", "{0}.svg".format(link))
                         try:
-                            symlink(root,
-                                    ldir + size + "/apps/" + link + ".svg")
+                            symlink(root_icon, link_path)
                         except FileExistsError:
                             continue
 elif platform == "osx":
     print("\nGenerating OSX theme...")
-    odir = "numix-{0}.icns/".format(theme)
-    for ext in ["icns", "pngs", "vectors"]:
-        mkdir(odir + ext)
     try:
         ink_flag = call(['which', 'png2icns'], stdout=PIPE, stderr=PIPE)
         if ink_flag != 0:
-            raise Exception
-    except (FileNotFoundError, Exception):
+            raise PNG2IcnsNotInstalled
+    except (FileNotFoundError, PNG2IcnsNotInstalled):
         exit("You will need png2icns in order to generate OSX theme")
+
+    osx_dir = "numix-{0}.icns".format(theme)
+    mkdir(osx_dir, ["icns", "pngs", "vectors"])
     for icon in icons:
         for name in icons[icon].get("osx", []):
-            if path.exists("icons/" + theme + "/48/" + icon + ".svg"):
-                copy2("icons/" + theme + "48/" + icon + ".svg",
-                      odir + "vectors/" + name + ".svg")
-                convert_svg2png("icons/" + theme + "/48/" + icon + ".svg",
-                                odir + "pngs/" + name + ".png", 1024, 1024)
-                call(["png2icns", odir + "icns/" + name + ".icn",
-                      odir + "pngs/" + name + ".png"],
+            input_icon = path.join("icons", theme, "48",
+                                   "{0}.svg".format(icon))
+            output_vector = path.join(
+                osx_dir, "vectors", "{0}.svg".format(name))
+            output_png = path.join(osx_dir, "pngs", "{0}.png".format(name))
+            output_icns = path.join(osx_dir, "icns", "{0}.icn".format(name))
+            if path.exists(input_icon):
+                copy2(input_icon, output_vector)
+                convert_svg2png(input_icon, output_png, 1024, 1024)
+                call(["png2icns", output_icns, output_png],
                      stdout=PIPE, stderr=PIPE)
 # Clean Up
-print("Done!\n")
-exit(0)
+exit("Done!\n")

--- a/gen.py
+++ b/gen.py
@@ -176,7 +176,7 @@ elif platform == "osx":
         ink_flag = call(['which', 'png2icns'], stdout=PIPE, stderr=PIPE)
         if ink_flag != 0:
             raise PNG2IcnsNotInstalled
-    except (FileNotFoundError, PNG2IcnsNotInstalled):
+    except PNG2IcnsNotInstalled:
         exit("You will need png2icns in order to generate OSX theme")
 
     osx_dir = "numix-{0}.icns".format(theme)


### PR DESCRIPTION
Replace paths from `theme/icons/sizes..` to `path.join("theme", "icons", "size")` This will allow users to build the icons in Windows and Unix systems. 
Also, I've removed unneeded code, duplicate code, cleaned variables that were not used or not needed =)
And added an input to ask the user to remove the old build if it's already exists
![screenshot from 2017-01-15 21-03-33](https://cloud.githubusercontent.com/assets/7660997/21965727/1e312e4e-db66-11e6-85f5-aaa5719ae350.png)

`pylint gen.py` now gives 10/10 as a score =)
![screenshot from 2017-01-15 21-02-27](https://cloud.githubusercontent.com/assets/7660997/21965720/f9de3564-db65-11e6-9b25-74a6b5dcb453.png)
