### PR TITLE
Add symlink for plex-media-player

### DIFF
--- a/data.json
+++ b/data.json
@@ -9720,7 +9720,8 @@
                 "chrome-fpniocchabmgenibceglhnfeimmdhdfm-Default",
                 "openpht",
                 "plex",
-                "plex-icon-256"
+                "plex-icon-256",
+                "plex-media-player"
             ]
         }
     },


### PR DESCRIPTION
Just need a symlink for [plex-media-player](https://github.com/plexinc/plex-media-player). Unfortunately upstream does not provide their own `.desktop` file to be used across all distros, so I'm basing the icon name on the `.desktop` file from [this aur package](https://aur.archlinux.org/packages/plex-media-player/). Hopefully if any other distros choose to package this program they use the same convention.