### PR TITLE
Fixes #3573

### DIFF
--- a/data.json
+++ b/data.json
@@ -2015,8 +2015,9 @@
     },
     "calendar-red-31": {
         "linux": {
-            "root": "calendar-red-31",
+            "root": "office-calendar",
             "symlinks": [
+                "calendar-red-31",
                 "date",
                 "dates",
                 "dayfolder",
@@ -2024,7 +2025,6 @@
                 "gnome-mime-text-x-vcalendar",
                 "gnome-planner",
                 "korganizer",
-                "office-calendar",
                 "office-date",
                 "org.gnome.Calendar",
                 "plan",


### PR DESCRIPTION
The icon file name is still `calendar-red-31.svg` so that it's sensibly organized, but when the theme is generated the root icon will be `office-calendar.svg` instead.