### PR TITLE
Added new symlink for Netflix Chromium App

### DIFF
--- a/data.json
+++ b/data.json
@@ -8706,6 +8706,7 @@
             "symlinks": [
                 "chrome-ahdabofbdlkjeniniajfcdlhanijbakd-Default",
                 "chrome-deceagebecbceejblnlcjooeohmmeldh-Default",
+                "chrome-cgbnengjfcijdonppjmgiodcdincmebo-Default"
                 "netflix",
                 "NetflixIcon",
                 "web-netflix"

--- a/data.json
+++ b/data.json
@@ -8706,7 +8706,7 @@
             "symlinks": [
                 "chrome-ahdabofbdlkjeniniajfcdlhanijbakd-Default",
                 "chrome-deceagebecbceejblnlcjooeohmmeldh-Default",
-                "chrome-cgbnengjfcijdonppjmgiodcdincmebo-Default"
+                "chrome-cgbnengjfcijdonppjmgiodcdincmebo-Default",
                 "netflix",
                 "NetflixIcon",
                 "web-netflix"


### PR DESCRIPTION
I added Netflix as a Chromium app on Fedora 25 and noticed the icon wasn't themed because it used a different name, so I added that to the symlinks of the existing Netflix icon.