### PR TITLE
Symlink for plexmediaplayer

### DIFF
--- a/data.json
+++ b/data.json
@@ -9851,7 +9851,8 @@
                 "openpht",
                 "plex",
                 "plex-icon-256",
-                "plex-media-player"
+                "plex-media-player",
+                "plexmediaplayer"
             ]
         }
     },


### PR DESCRIPTION
This is the replacement for Plex Home Theater, so the icon is the same.