### PR TITLE
Add symlink for msiexec

### DIFF
--- a/data.json
+++ b/data.json
@@ -15006,7 +15006,10 @@
     },
     "wine-uninstaller": {
         "linux": {
-            "root": "wine-uninstaller"
+            "root": "wine-uninstaller",
+            "symlinks": [
+                "msiexec"
+            ]
         }
     },
     "wine-winecfg": {


### PR DESCRIPTION
Seems to be a Fedora specific thing, also not sure if I'm doing this right.