### PR TITLE
add .editorconfig & markdownlint the README

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+indent_size = 2
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+insert_final_newline = false
+
+[*.{py,json}]
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -1,25 +1,29 @@
 # Numix Core
-This repository powers the generation of the all the Numix app icon themes accross all platforms. This new method is designed to make keeping themes on different platforms on feature parity easier as well as making it as simple as possible to add support for new platforms. Licensed under the GPL-3.0+
 
+This repository powers the generation of the all the Numix app icon themes accross all platforms. This new method is designed to make keeping themes on different platforms on feature parity easier as well as making it as simple as possible to add support for new platforms. Licensed under the GPL-3.0+
 
 ## Artwork
 
 ### Icon Requests
+
 Please report icon requests in this repo, providing all the details required. For normal applications follow [this video tutorial](https://plus.google.com/+NumixprojectOrg/posts/DkRmhFZuWez), for Steam games follow [this one](https://www.youtube.com/watch?v=BuUy4CzCoXc) and for Chrome apps just post a link to the webstore page. When filing your request please be respectful, patient, and remember that development is done solely on the back of donations.
 
 ### Contributions
+
 We accept contributions, read [this page](https://github.com/numixproject/numix-core/wiki/Contributing) for more info.
 
 ### Hardcoded Icons
-To deal with hardcoded application icons Numix uses the [hardcode-fixer](https://github.com/Foggalong/hardcode-fixer) script. A list of the applications supported by the script can be found [here](https://github.com/Foggalong/hardcode-fixer/wiki/App-Support).
 
+To deal with hardcoded application icons Numix uses the [hardcode-fixer](https://github.com/Foggalong/hardcode-fixer) script. A list of the applications supported by the script can be found [here](https://github.com/Foggalong/hardcode-fixer/wiki/App-Support).
 
 ## Script
 
 ### Dependencies
+
 The script needs Python 3.x to run. The exporting-to-PNG part of the script currently uses [Cairo](https://cairographics.org/) or [Inkscape](https://inkscape.org/). The OSX packaging needs [libicns](http://icns.sourceforge.net/) for the `png2icns` command.
 
 ### How To Use
-1. Download the repo
-2. Run `gen.py --theme {square,circle} --platform {linux,osx,android}`
-3. Get your generated package
+
+1 - Download the repo
+2 - Run `gen.py --theme {square,circle} --platform {linux,osx,android}`
+3 - Get your generated package

--- a/README.md
+++ b/README.md
@@ -24,6 +24,6 @@ The script needs Python 3.x to run. The exporting-to-PNG part of the script curr
 
 ### How To Use
 
-1 - Download the repo
-2 - Run `gen.py --theme {square,circle} --platform {linux,osx,android}`
-3 - Get your generated package
+1. Download the repo
+2. Run `gen.py --theme {square,circle} --platform {linux,osx,android}`
+3. Get your generated package

--- a/README.md
+++ b/README.md
@@ -1,29 +1,25 @@
 # Numix Core
-
 This repository powers the generation of the all the Numix app icon themes accross all platforms. This new method is designed to make keeping themes on different platforms on feature parity easier as well as making it as simple as possible to add support for new platforms. Licensed under the GPL-3.0+
+
 
 ## Artwork
 
 ### Icon Requests
-
 Please report icon requests in this repo, providing all the details required. For normal applications follow [this video tutorial](https://plus.google.com/+NumixprojectOrg/posts/DkRmhFZuWez), for Steam games follow [this one](https://www.youtube.com/watch?v=BuUy4CzCoXc) and for Chrome apps just post a link to the webstore page. When filing your request please be respectful, patient, and remember that development is done solely on the back of donations.
 
 ### Contributions
-
 We accept contributions, read [this page](https://github.com/numixproject/numix-core/wiki/Contributing) for more info.
 
 ### Hardcoded Icons
-
 To deal with hardcoded application icons Numix uses the [hardcode-fixer](https://github.com/Foggalong/hardcode-fixer) script. A list of the applications supported by the script can be found [here](https://github.com/Foggalong/hardcode-fixer/wiki/App-Support).
+
 
 ## Script
 
 ### Dependencies
-
 The script needs Python 3.x to run. The exporting-to-PNG part of the script currently uses [Cairo](https://cairographics.org/) or [Inkscape](https://inkscape.org/). The OSX packaging needs [libicns](http://icns.sourceforge.net/) for the `png2icns` command.
 
 ### How To Use
-
 1. Download the repo
 2. Run `gen.py --theme {square,circle} --platform {linux,osx,android}`
 3. Get your generated package


### PR DESCRIPTION
This PR adds a .editorconfig file, which will force indent size & type for the data.json. As you can see here in #3856 few lines didn't respect the indent size, this will fix it for all the cases where the contributor uses a text editor that supports editorconfig (Atom, VSCode, Gedit, Builder, Sublime Text....)

And also remove some unneeded empty lines on the README.md (there's now a project on Github that defines few rules for a cleaner and readable Markdown file)