### PR TITLE
Fix syntax error in data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -12430,7 +12430,7 @@
             "root": "steam",
             "symlinks": [
                 "10B4_steam.0",
-                "com.valvesoftware.Steam"
+                "com.valvesoftware.Steam",
                 "steam-launcher",
                 "steamos-logo-icon",
                 "steampowered"


### PR DESCRIPTION
There was a comma missing, which was confusing gen.py