### PR TITLE
Symlink for FileManager Actions

### DIFF
--- a/data.json
+++ b/data.json
@@ -4371,6 +4371,7 @@
                 "caja-actions",
                 "dde-file-manager",
                 "filerunner",
+                "fma-config-tool",
                 "Insight-FileManager",
                 "kfm",
                 "nautilus",


### PR DESCRIPTION
*Nautilus Actions* got renamed to *FileManager Actions*. Likewise the icon was.