### PR TITLE
Icons and entry for web Markdown editor, Dillinger.

### DIFF
--- a/data.json
+++ b/data.json
@@ -14877,6 +14877,11 @@
             ]
         }
     },
+    "web-dillinger": {
+        "linux": {
+            "root": "web-dillinger"
+        }
+    },
     "web-duckduckgo": {
         "linux": {
             "root": "web-duckduckgo"

--- a/icons/circle/48/web-dillinger.svg
+++ b/icons/circle/48/web-dillinger.svg
@@ -1,0 +1,17 @@
+<svg version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <linearGradient id="linearGradient840" x1="1" x2="47" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#373d49" offset="0"/>
+   <stop style="stop-color:#404754" offset="1"/>
+  </linearGradient>
+ </defs>
+ <path d="m36.31 5c5.859 4.062 9.688 10.831 9.688 18.5 0 12.426-10.07 22.5-22.5 22.5-7.669 0-14.438-3.828-18.5-9.688 1.037 1.822 2.306 3.499 3.781 4.969 4.085 3.712 9.514 5.969 15.469 5.969 12.703 0 23-10.298 23-23 0-5.954-2.256-11.384-5.969-15.469-1.469-1.475-3.147-2.744-4.969-3.781zm4.969 3.781c3.854 4.113 6.219 9.637 6.219 15.719 0 12.703-10.297 23-23 23-6.081 0-11.606-2.364-15.719-6.219 4.16 4.144 9.883 6.719 16.219 6.719 12.703 0 23-10.298 23-23 0-6.335-2.575-12.06-6.719-16.219z" style="opacity:.05"/>
+ <path d="m41.28 8.781c3.712 4.085 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.113 3.854 9.637 6.219 15.719 6.219 12.703 0 23-10.298 23-23 0-6.081-2.364-11.606-6.219-15.719z" style="opacity:.1"/>
+ <path d="m31.25 2.375c8.615 3.154 14.75 11.417 14.75 21.13 0 12.426-10.07 22.5-22.5 22.5-9.708 0-17.971-6.135-21.12-14.75a23 23 0 0 0 44.875-7 23 23 0 0 0-16-21.875z" style="opacity:.2"/>
+ <g transform="matrix(0,-1,1,0,0,48)" style="fill:#501616">
+  <path d="m24 1c12.703 0 23 10.297 23 23s-10.297 23-23 23-23-10.297-23-23 10.297-23 23-23z" style="fill:url(#linearGradient840)"/>
+ </g>
+ <path d="m40.03 7.531c3.712 4.084 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.178 4.291 10.01 6.969 16.469 6.969 12.703 0 23-10.298 23-23 0-6.462-2.677-12.291-6.969-16.469z" style="opacity:.1"/>
+ <path d="m16 13v24h7c4.9444 0 8.415-1.761 10.428-4.2383 2.0128-2.4772 2.5723-5.4284 2.5723-7.7617s-0.55951-5.2845-2.5723-7.7617c-2.0128-2.4772-5.4833-4.2383-10.428-4.2383zm4 4h3c4.0556 0 6.085 1.239 7.3223 2.7617 1.2372 1.5228 1.6777 3.5716 1.6777 5.2383s-0.44049 3.7155-1.6777 5.2383c-1.2372 1.5228-3.2667 2.7617-7.3223 2.7617h-3z" style="color-rendering:auto;color:#000000;dominant-baseline:auto;font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;image-rendering:auto;isolation:auto;mix-blend-mode:normal;opacity:.1;shape-padding:0;shape-rendering:auto;solid-color:#000000;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none;white-space:normal"/>
+ <path d="m15 12v24h7c4.9444 0 8.415-1.761 10.428-4.2383 2.0128-2.4772 2.5723-5.4284 2.5723-7.7617s-0.55951-5.2845-2.5723-7.7617c-2.0128-2.4772-5.4833-4.2383-10.428-4.2383zm4 4h3c4.0556 0 6.085 1.239 7.3223 2.7617 1.2372 1.5228 1.6777 3.5716 1.6777 5.2383s-0.44049 3.7155-1.6777 5.2383c-1.2372 1.5228-3.2667 2.7617-7.3223 2.7617h-3z" style="color-rendering:auto;color:#000000;dominant-baseline:auto;fill:#eee;font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;image-rendering:auto;isolation:auto;mix-blend-mode:normal;shape-padding:0;shape-rendering:auto;solid-color:#000000;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none;white-space:normal"/>
+</svg>

--- a/icons/square/48/web-dillinger.svg
+++ b/icons/square/48/web-dillinger.svg
@@ -1,0 +1,21 @@
+<svg width="48" height="48" version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <linearGradient id="linearGradient4501" x1="-47" x2="-1" y1="2.8779e-15" y2="6.1232e-17" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#373d49" offset="0"/>
+   <stop style="stop-color:#404754" offset="1"/>
+  </linearGradient>
+ </defs>
+ <g transform="translate(0 3.949e-5)">
+  <path d="m1 43v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4zm0 0.5v0.5c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.5c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.02"/>
+  <path d="m1 43.25v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.05"/>
+  <path d="m1 43v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.1"/>
+ </g>
+ <rect transform="rotate(-90)" x="-47" y="1" width="46" height="46" rx="4" style="fill:url(#linearGradient4501)"/>
+ <g transform="translate(0 3.949e-5)">
+  <g transform="translate(0 -1004.4)">
+   <path d="m1 1043.4v4c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-4c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.1"/>
+  </g>
+ </g>
+ <path d="m15 12v24h7c4.9444 0 8.415-1.761 10.428-4.2383 2.0128-2.4772 2.5723-5.4284 2.5723-7.7617s-0.55951-5.2845-2.5723-7.7617c-2.0128-2.4772-5.4833-4.2383-10.428-4.2383zm4 4h3c4.0556 0 6.085 1.239 7.3223 2.7617 1.2372 1.5228 1.6777 3.5716 1.6777 5.2383s-0.44049 3.7155-1.6777 5.2383c-1.2372 1.5228-3.2667 2.7617-7.3223 2.7617h-3z" style="color-rendering:auto;color:#000000;dominant-baseline:auto;font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;image-rendering:auto;isolation:auto;mix-blend-mode:normal;opacity:.1;shape-padding:0;shape-rendering:auto;solid-color:#000000;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none;white-space:normal"/>
+ <path d="m15 11v24h7c4.9444 0 8.415-1.761 10.428-4.2383 2.0128-2.4772 2.5723-5.4284 2.5723-7.7617s-0.55951-5.2845-2.5723-7.7617c-2.0128-2.4772-5.4833-4.2383-10.428-4.2383zm4 4h3c4.0556 0 6.085 1.239 7.3223 2.7617 1.2372 1.5228 1.6777 3.5716 1.6777 5.2383s-0.44049 3.7155-1.6777 5.2383c-1.2372 1.5228-3.2667 2.7617-7.3223 2.7617h-3z" style="color-rendering:auto;color:#000000;dominant-baseline:auto;fill:#eee;font-feature-settings:normal;font-variant-alternates:normal;font-variant-caps:normal;font-variant-ligatures:normal;font-variant-numeric:normal;font-variant-position:normal;image-rendering:auto;isolation:auto;mix-blend-mode:normal;shape-padding:0;shape-rendering:auto;solid-color:#000000;text-decoration-color:#000000;text-decoration-line:none;text-decoration-style:solid;text-indent:0;text-orientation:mixed;text-transform:none;white-space:normal"/>
+</svg>


### PR DESCRIPTION
![iconified_web-dillinger](https://user-images.githubusercontent.com/11786132/30525914-d7b33e76-9c53-11e7-8332-5dca352ab18f.png)

Perhaps not the most original design...

It occurs to me that my last PR for The Lounge is a web only instance, so it could probably be renamed with a `web-` suffix. I'll PR that if that would be preferred.