### PR TITLE
LibreOffice Writer circle icon consistent with oficial branding

### DIFF
--- a/icons/circle/48/libreoffice-writer.svg
+++ b/icons/circle/48/libreoffice-writer.svg
@@ -1,46 +1,298 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">
- <defs>
-  <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-   <stop style="stop-color:#3aa0b2;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#40acc1;stop-opacity:1"/>
-  </linearGradient>
- </defs>
- <g>
-  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
-  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
-  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
- </g>
- <g>
-  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3764);fill-opacity:1"/>
- </g>
- <g>
-  <g>
-   <g transform="translate(1,1)">
-    <g style="opacity:0.1">
-     <!-- color: #40acc1 -->
-     <g>
-      <path d="m 14.781 11 c -0.98 0 -1.781 0.801 -1.781 1.781 l 0 22.438 c 0 0.98 0.801 1.781 1.781 1.781 l 20.438 0 c 0.984 0 1.785 -0.801 1.785 -1.781 l 0 -18.223 l -6 -5.996 m -16.223 0" style="fill:#000;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-      <use xlink:href="#SVGCleanerId_0"/>
-     </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg10634"
+   inkscape:version="0.92.2 (unknown)"
+   sodipodi:docname="libreoffice-writer.svg">
+  <defs
+     id="defs10628">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9334-46-1"
+       id="linearGradient10595"
+       gradientUnits="userSpaceOnUse"
+       x1="116.48132"
+       y1="976.30756"
+       x2="116.48132"
+       y2="992.32819" />
+    <linearGradient
+       id="linearGradient9334-46-1"
+       inkscape:collect="always">
+      <stop
+         id="stop9336-9-6"
+         offset="0"
+         style="stop-color: rgb(3, 105, 163); stop-opacity: 1;" />
+      <stop
+         id="stop9338-9-8"
+         offset="1"
+         style="stop-color: rgb(2, 63, 98); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9334-46-1"
+       id="linearGradient10587"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.357143,0,0,1,73.9293,0)"
+       x1="117.71875"
+       y1="976.30396"
+       x2="117.71875"
+       y2="992.23761" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9334-46-1"
+       id="linearGradient10589"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.416667,0,0,1,67.084,0)"
+       x1="117.71875"
+       y1="982.36218"
+       x2="117.71875"
+       y2="989.40918" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9334-46-1"
+       id="linearGradient10591"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.14286,0,0,1,-16.4287,0)"
+       x1="117.71875"
+       y1="982.36218"
+       x2="117.71875"
+       y2="989.40918" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9334-46-1"
+       id="linearGradient10593"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5,0,0,1,-57.5006,0)"
+       x1="117.71875"
+       y1="982.36218"
+       x2="117.71875"
+       y2="989.40918" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9334-46-1"
+       id="linearGradient10597"
+       gradientUnits="userSpaceOnUse"
+       x1="208.96875"
+       y1="-780.60657"
+       x2="208.96875"
+       y2="-766.66815" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9364-1"
+       id="linearGradient10599"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.875,0,0,0.666667,22.75,-391.879)"
+       x1="230"
+       y1="-581.63782"
+       x2="230"
+       y2="-578.63782" />
+    <linearGradient
+       id="linearGradient9364-1">
+      <stop
+         style="stop-color: rgb(99, 187, 238); stop-opacity: 1;"
+         offset="0"
+         id="stop9366-0" />
+      <stop
+         style="stop-color: rgb(170, 220, 247); stop-opacity: 1;"
+         offset="1"
+         id="stop9368-84" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10292-3"
+       id="linearGradient10601"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.875,0,0,0.8,-84.875,-1718.04)"
+       x1="345"
+       y1="1173"
+       x2="345"
+       y2="1178" />
+    <linearGradient
+       id="linearGradient10292-3"
+       inkscape:collect="always">
+      <stop
+         id="stop10294-6"
+         offset="0"
+         style="stop-color: rgb(102, 102, 102); stop-opacity: 1;" />
+      <stop
+         id="stop10296-0"
+         offset="1"
+         style="stop-color: rgb(51, 51, 51); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3083-6-8-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.2702155,0.2702155,0,-246.40791,180.28071)"
+       x1="1"
+       x2="47">
+      <stop
+         style="stop-color:#e4e4e4;stop-opacity:1"
+         id="stop2-7-4" />
+      <stop
+         offset="1"
+         style="stop-color:#eee;stop-opacity:1"
+         id="stop4-2-3" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="36.604445"
+     inkscape:cy="14.445984"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="999"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata10631">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(246.13769,-167.58072)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path19-6"
+       style="display:inline;fill:url(#linearGradient3083-6-8-9);fill-opacity:1;stroke-width:0.27021548"
+       d="m -241.58618,167.80867 c -3.2145,8.31482 -1.60724,4.15727 0,0 z m 0,0 c -2.62433,0.72742 -4.55151,3.13072 -4.55151,5.98796 0,3.43255 2.7824,6.21498 6.21494,6.21498 2.85619,0 5.25949,-1.92691 5.98798,-4.55154 z m 7.65061,7.65061 c -8.31481,3.2145 -4.15726,1.60724 0,0 z" />
+    <g
+       transform="matrix(0.2702155,0,0,0.2702155,-246.4079,167.31039)"
+       id="g15-8"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9-2"
+         style="opacity:0.05"
+         d="m 36.31,5 c 5.859,4.062 9.688,10.831 9.688,18.5 0,12.426 -10.07,22.5 -22.5,22.5 -7.669,0 -14.438,-3.828 -18.5,-9.688 1.037,1.822 2.306,3.499 3.781,4.969 4.085,3.712 9.514,5.969 15.469,5.969 12.703,0 23,-10.298 23,-23 0,-5.954 -2.256,-11.384 -5.969,-15.469 C 39.81,7.306 38.132,6.037 36.31,5 Z m 4.969,3.781 c 3.854,4.113 6.219,9.637 6.219,15.719 0,12.703 -10.297,23 -23,23 -6.081,0 -11.606,-2.364 -15.719,-6.219 4.16,4.144 9.883,6.719 16.219,6.719 12.703,0 23,-10.298 23,-23 0,-6.335 -2.575,-12.06 -6.719,-16.219 z" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path11-9"
+         style="opacity:0.1"
+         d="m 41.28,8.781 c 3.712,4.085 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 -5.954,0 -11.384,-2.256 -15.469,-5.969 4.113,3.854 9.637,6.219 15.719,6.219 12.703,0 23,-10.298 23,-23 0,-6.081 -2.364,-11.606 -6.219,-15.719 z" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13-9"
+         style="opacity:0.2"
+         d="M 31.25,2.375 C 39.865,5.529 46,13.792 46,23.505 c 0,12.426 -10.07,22.5 -22.5,22.5 -9.708,0 -17.971,-6.135 -21.12,-14.75 a 23,23 0 0 0 44.875,-7 23,23 0 0 0 -16,-21.875 z" />
     </g>
-   </g>
+    <g
+       style="display:inline"
+       transform="matrix(0.43699276,0,0,0.43699276,-206.93436,137.53009)"
+       id="g5054">
+      <g
+         id="g11787-9"
+         style="display:inline;fill:url(#linearGradient10595);fill-opacity:1"
+         transform="matrix(1.99996,0,0,2,-313.74688,-1888.4713)">
+        <rect
+           y="984.36108"
+           x="115.00113"
+           height="1"
+           width="2.5"
+           id="rect11789-1"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient10587);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.01121998;marker:none" />
+        <rect
+           y="982.36108"
+           x="115.00113"
+           height="1"
+           width="2.5"
+           id="rect11791-9"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient10589);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.01121998;marker:none" />
+        <rect
+           y="986.36108"
+           x="115.00113"
+           height="1"
+           width="8"
+           id="rect11793-6"
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient10591);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.01121998;marker:none" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient10593);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.01121998;marker:none"
+           id="rect11795-2"
+           width="6"
+           height="1"
+           x="115.00113"
+           y="988.36108" />
+      </g>
+      <g
+         id="g12037-5"
+         transform="matrix(0.999981,0,0,1,-273.74538,836.88864)"
+         style="display:inline">
+        <g
+           transform="translate(-19,20)"
+           id="g12059-4">
+          <rect
+             y="-780.63782"
+             x="216"
+             height="6"
+             width="9"
+             id="rect12049-4"
+             style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient10597);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none" />
+          <rect
+             style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient10599);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none"
+             id="rect12051-9"
+             width="7"
+             height="4"
+             x="217"
+             y="-779.63776" />
+          <path
+             inkscape:connector-curvature="0"
+             style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient10601);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none"
+             d="m 221,-776.6378 -2,-2.5 -2,3 v 0.5 h 7 v -0.5 l -1.5,-1.5 z"
+             id="path12053-9"
+             sodipodi:nodetypes="cccccccc" />
+        </g>
+      </g>
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path17-1"
+       style="display:inline;fill:#03659d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.27021548"
+       d="m -239.92275,167.58062 c -0.57636,0 -1.13381,0.081 -1.66343,0.22805 l 7.65061,7.65061 c 0.14671,-0.52961 0.22806,-1.08627 0.22806,-1.66344 0,-3.43256 -2.78242,-6.21498 -6.21497,-6.21498 z" />
+    <g
+       transform="matrix(0.2702155,0,0,0.2702155,-246.4079,167.31039)"
+       id="g23-0"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path21-7"
+         style="opacity:0.1"
+         d="m 40.03,7.531 c 3.712,4.084 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 C 17.045,46 11.615,43.744 7.53,40.031 11.708,44.322 17.54,47 23.999,47 c 12.703,0 23,-10.298 23,-23 0,-6.462 -2.677,-12.291 -6.969,-16.469 z" />
+    </g>
   </g>
- </g>
- <g>
-  <g>
-   <!-- color: #40acc1 -->
-   <g>
-    <path d="M 14.781,11 C 13.801,11 13,11.801 13,12.781 l 0,22.438 C 13,36.199 13.801,37 14.781,37 l 20.438,0 c 0.984,0 1.785,-0.801 1.785,-1.781 l 0,-18.223 -6,-5.996 m -16.223,0" style="fill:#ecf2f2;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 37 17 -6 0 6 6 m 0 -6" id="SVGCleanerId_0" style="fill:#000;fill-opacity:0.2;stroke:none;fill-rule:nonzero"/>
-    <path d="m 16.355,14 15.293,0 c 0.195,0 0.355,0.16 0.355,0.355 l 0,1.289 c 0,0.195 -0.16,0.352 -0.355,0.352 l -15.293,0 C 16.16,15.996 16,15.84 16,15.644 l 0,-1.289 C 16,14.16 16.16,14 16.355,14 m 0,0" style="fill:#5ba3ec;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 37,17 -6,0 0,-5.996 M 37,17" style="fill:#fff;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 16.355,20 15.293,0 c 0.195,0 0.355,0.156 0.355,0.352 l 0,1.289 c 0,0.199 -0.16,0.355 -0.355,0.355 l -15.293,0 C 16.16,21.996 16,21.84 16,21.641 l 0,-1.289 C 16,20.157 16.16,20 16.355,20 m 0,0" style="fill:#5ba3ec;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 16.355,26 15.293,0 c 0.195,0 0.355,0.16 0.355,0.355 l 0,1.289 c 0,0.195 -0.16,0.355 -0.355,0.355 l -15.293,0 C 16.16,27.999 16,27.839 16,27.644 l 0,-1.289 C 16,26.16 16.16,26 16.355,26 m 0,0" style="fill:#5ba3ec;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 16.355,31.996 15.293,0 c 0.195,0 0.355,0.16 0.355,0.355 l 0,1.289 c 0,0.195 -0.16,0.355 -0.355,0.355 l -15.293,0 C 16.16,33.995 16,33.835 16,33.64 l 0,-1.289 c 0,-0.195 0.16,-0.355 0.355,-0.355 m 0,0" style="fill:#5ba3ec;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-   </g>
-  </g>
- </g>
- <g>
-  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
- </g>
 </svg>


### PR DESCRIPTION
LibreOffice Writer circle icon consistent with [look and feel of oficial branding](https://wiki.documentfoundation.org/Visual_Elements). So people will recognize it more easily.

The icon is based on libreoffice-main.svg file and mixed with [oficial graphical elements and color pallete](https://wiki.documentfoundation.org/File:LibreOffice_Initial_Icons-pre_final.svg).

![proposal-libreoffice-writer](https://user-images.githubusercontent.com/6515809/31469664-cf065a70-ae9f-11e7-9aa3-bb01eec84b74.png)
