### PR TITLE
LibreOffice Calc circle icon consistent with oficial branding

### DIFF
--- a/icons/circle/48/libreoffice-calc.svg
+++ b/icons/circle/48/libreoffice-calc.svg
@@ -1,44 +1,237 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 48 48">
- <defs>
-  <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-   <stop style="stop-color:#37b770;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#3dc57a;stop-opacity:1"/>
-  </linearGradient>
- </defs>
- <g>
-  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
-  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
-  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
- </g>
- <g>
-  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3764);fill-opacity:1"/>
- </g>
- <g>
-  <g>
-   <g transform="translate(1,1)">
-    <g style="opacity:0.1">
-     <!-- color: #3dc57a -->
-     <g>
-      <path d="m 14.656 11 c -1.473 0 -2.66 1.184 -2.66 2.656 l 0 20.684 c 0 1.477 1.184 2.66 2.66 2.66 l 20.684 0 c 1.473 0 2.66 -1.184 2.66 -2.66 l 0 -17.344 l -6 -5.996 m -17.344 0" style="fill:#000;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-      <use xlink:href="#SVGCleanerId_0"/>
-      <path d="m 38 17 l -6 0 l 0 -5.996 m 6 5.996" style="fill:#000;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-     </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg9922"
+   inkscape:version="0.92.2 (unknown)"
+   sodipodi:docname="libreoffice-calc.svg">
+  <defs
+     id="defs9916">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13214-3"
+       id="linearGradient23911"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-123,-1753.64)"
+       x1="592.2019"
+       y1="968.76935"
+       x2="592.64386"
+       y2="1000.1472" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient13214-3">
+      <stop
+         style="stop-color: rgb(24, 163, 3); stop-opacity: 1;"
+         offset="0"
+         id="stop13216-0" />
+      <stop
+         style="stop-color: rgb(16, 104, 2); stop-opacity: 1;"
+         offset="1"
+         id="stop13218-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15606-6"
+       id="linearGradient23913"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.2,0,151.925)"
+       x1="481"
+       y1="-759.63782"
+       x2="481"
+       y2="-764.63782" />
+    <linearGradient
+       id="linearGradient15606-6">
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
+         offset="0"
+         id="stop15608-8" />
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
+         offset="1"
+         id="stop15610-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3083-6-8-9-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.27021286,0.27021286,0,-74.050754,144.75095)"
+       x1="1"
+       x2="47">
+      <stop
+         style="stop-color:#e4e4e4;stop-opacity:1"
+         id="stop2-7-4-0" />
+      <stop
+         offset="1"
+         style="stop-color:#eee;stop-opacity:1"
+         id="stop4-2-3-86" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="28.449855"
+     inkscape:cy="28.77494"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="999"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata9919">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(73.78055,-132.05095)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path19-6-2"
+       style="display:inline;fill:url(#linearGradient3083-6-8-9-7);fill-opacity:1;stroke-width:0.27021283"
+       d="m -69.229083,132.27905 c -3.214451,8.31473 -1.607223,4.1572 0,0 z m 0,0 c -2.624301,0.72738 -4.551467,3.13067 -4.551467,5.98788 0,3.43252 2.782385,6.21491 6.214897,6.21491 2.856151,0 5.259424,-1.92687 5.987914,-4.55147 z m 7.650536,7.65052 c -8.314719,3.21446 -4.157221,1.60723 0,0 z" />
+    <g
+       transform="matrix(0.27021285,0,0,0.27021285,-74.05076,131.78073)"
+       id="g15-8-4"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9-2-7"
+         style="opacity:0.05"
+         d="m 36.31,5 c 5.859,4.062 9.688,10.831 9.688,18.5 0,12.426 -10.07,22.5 -22.5,22.5 -7.669,0 -14.438,-3.828 -18.5,-9.688 1.037,1.822 2.306,3.499 3.781,4.969 4.085,3.712 9.514,5.969 15.469,5.969 12.703,0 23,-10.298 23,-23 0,-5.954 -2.256,-11.384 -5.969,-15.469 C 39.81,7.306 38.132,6.037 36.31,5 Z m 4.969,3.781 c 3.854,4.113 6.219,9.637 6.219,15.719 0,12.703 -10.297,23 -23,23 -6.081,0 -11.606,-2.364 -15.719,-6.219 4.16,4.144 9.883,6.719 16.219,6.719 12.703,0 23,-10.298 23,-23 0,-6.335 -2.575,-12.06 -6.719,-16.219 z" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path11-9-9"
+         style="opacity:0.1"
+         d="m 41.28,8.781 c 3.712,4.085 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 -5.954,0 -11.384,-2.256 -15.469,-5.969 4.113,3.854 9.637,6.219 15.719,6.219 12.703,0 23,-10.298 23,-23 0,-6.081 -2.364,-11.606 -6.219,-15.719 z" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path13-9-3"
+         style="opacity:0.2"
+         d="M 31.25,2.375 C 39.865,5.529 46,13.792 46,23.505 c 0,12.426 -10.07,22.5 -22.5,22.5 -9.708,0 -17.971,-6.135 -21.12,-14.75 a 23,23 0 0 0 44.875,-7 23,23 0 0 0 -16,-21.875 z" />
     </g>
-   </g>
+    <g
+       style="display:inline"
+       id="g28878-9"
+       transform="matrix(0.43767483,0,0,0.43767483,-277.76305,473.48084)">
+      <g
+         id="g15626-4">
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#ccf4c6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           id="rect15558-5-5"
+           width="16"
+           height="13.000028"
+           x="472"
+           y="-772.63782" />
+        <rect
+           y="-772.63782"
+           x="472"
+           height="3.9999993"
+           width="15.999989"
+           id="rect7360-9"
+           style="display:inline;overflow:visible;visibility:visible;fill:#92e285;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+        <path
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient23911);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           d="m 472,-772.6378 v 1 2 1 2 1 2 1 2 1 h 16 v -1 -11 -1 h -1 -4 -1 -4 -1 -4 z m 1,1 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m -10,3 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m -10,3 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m -10,3 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z m 5,0 h 4 v 2 h -4 z"
+           id="rect6547-3"
+           inkscape:connector-curvature="0" />
+        <rect
+           y="-766.63782"
+           x="480"
+           height="7.9999647"
+           width="8"
+           id="rect7336-5"
+           style="display:inline;overflow:visible;visibility:visible;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           y="-765.63782"
+           x="481"
+           height="5.9999619"
+           width="6"
+           id="rect7362-7"
+           style="display:inline;overflow:visible;visibility:visible;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient23913);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           id="rect6567-0"
+           width="6"
+           height="5.9999619"
+           x="481"
+           y="-765.63782" />
+        <rect
+           y="-762.63782"
+           x="482"
+           height="2.9999723"
+           width="2"
+           id="rect6585-8"
+           style="display:inline;overflow:visible;visibility:visible;fill:#1c99e0;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#d36118;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           id="rect6587-1"
+           width="2"
+           height="4.9999609"
+           x="484"
+           y="-764.63782" />
+        <rect
+           style="display:inline;overflow:visible;visibility:visible;fill:#63bbee;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+           id="rect7350-9"
+           width="1"
+           height="1.9999989"
+           x="482"
+           y="-762.63782" />
+        <rect
+           y="-764.63782"
+           x="484"
+           height="3.9999883"
+           width="1"
+           id="rect7352-9"
+           style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+      </g>
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path17-1-4"
+       style="display:inline;fill:#137c02;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.27021283"
+       d="m -67.565653,132.05099 c -0.576365,0 -1.133809,0.081 -1.66343,0.22806 l 7.650536,7.65052 c 0.146723,-0.52962 0.22806,-1.08626 0.22806,-1.66344 0,-3.43251 -2.78238,-6.2149 -6.214896,-6.2149 z" />
+    <g
+       transform="matrix(0.27021285,0,0,0.27021285,-74.05076,131.78073)"
+       id="g23-0-9"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path21-7-2"
+         style="opacity:0.1"
+         d="m 40.03,7.531 c 3.712,4.084 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 C 17.045,46 11.615,43.744 7.53,40.031 11.708,44.322 17.54,47 23.999,47 c 12.703,0 23,-10.298 23,-23 0,-6.462 -2.677,-12.291 -6.969,-16.469 z" />
+    </g>
   </g>
- </g>
- <g>
-  <g>
-   <!-- color: #3dc57a -->
-   <g>
-    <path d="m 14.656,11 c -1.473,0 -2.66,1.184 -2.66,2.656 l 0,20.684 c 0,1.477 1.184,2.66 2.66,2.66 L 35.34,37 C 36.813,37 38,35.816 38,34.34 L 38,16.996 32,11 m -17.344,0" style="fill:#e5e5e5;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 38 17 -6 0 6 6 m 0 -6" id="SVGCleanerId_0" style="fill:#000;fill-opacity:0.2;stroke:none;fill-rule:nonzero"/>
-    <path d="m 38,17 -6,0 0,-5.996 M 38,17" style="fill:#fff;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 33 19 c 0 5.629 0 11.12 0 16 -5.617 0 -11.141 0 -16 0 0 -5.629 0 -11.12 0 -16 5.555 0 11.238 0 16 0 m -1 1 -8 0 0 4 8 0 m -9 -4 -5 0 0 4 5 0 m 9 1 -8 0 0 4 8 0 m -9 -4 -5 0 0 4 5 0 m 9 1 -8 0 0 4 8 0 m -9 -4 -5 0 0 4 5 0 m 0 -4" style="fill:#44c89c;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-   </g>
-  </g>
- </g>
- <g>
-  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
- </g>
 </svg>


### PR DESCRIPTION
LibreOffice Calc circle icon consistent with [look and feel of oficial branding](https://wiki.documentfoundation.org/Visual_Elements). So people will recognize it more easily.

The icon is based on libreoffice-main.svg file and mixed with [oficial graphical elements and color pallete](https://wiki.documentfoundation.org/File:LibreOffice_Initial_Icons-pre_final.svg).

![proposal-libreoffice-calc](https://user-images.githubusercontent.com/6515809/31469728-287eb7a0-aea0-11e7-9cfb-2e356a841960.png)
