### PR TITLE
LibreOffice Impress circle icon consistent with oficial branding

### DIFF
--- a/icons/circle/48/libreoffice-impress.svg
+++ b/icons/circle/48/libreoffice-impress.svg
@@ -1,44 +1,259 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
- <defs>
-  <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-   <stop style="stop-color:#f67c2a;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#f7883d;stop-opacity:1"/>
-  </linearGradient>
- </defs>
- <g>
-  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
-  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
-  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
- </g>
- <g>
-  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3764);fill-opacity:1"/>
- </g>
- <g>
-  <g>
-   <g transform="translate(1,1)">
-    <g style="opacity:0.1">
-     <!-- color: #f7883d -->
-     <g>
-      <path d="m 12.883 13 c -0.488 0 -0.883 0.399 -0.883 0.887 l 0 0.227 c 0 0.489 0.395 0.889 0.883 0.889 l 0.117 0 l 0 19.998 l -0.117 0 c -0.488 0 -0.883 0.399 -0.883 0.887 l 0 0.227 c 0 0.489 0.395 0.889 0.883 0.889 l 24.23 0 c 0.489 0 0.887 -0.401 0.887 -0.889 l 0 -0.227 c 0 -0.489 -0.399 -0.887 -0.887 -0.887 l -0.113 0 l 0 -19.998 l 0.113 0 c 0.489 0 0.887 -0.401 0.887 -0.889 l 0 -0.227 c 0 -0.489 -0.399 -0.887 -0.887 -0.887 l -24.23 0 z" transform="translate(-1,-1)"/>
-     </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg9202"
+   inkscape:version="0.92.2 (unknown)"
+   sodipodi:docname="libreoffice-impress.svg">
+  <defs
+     id="defs9196">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10119"
+       id="linearGradient54886-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.70312537,0,0,0.82868409,308.23387,-48.859819)"
+       x1="756"
+       y1="-860.63782"
+       x2="756"
+       y2="-876.63782" />
+    <linearGradient
+       id="linearGradient10119">
+      <stop
+         id="stop10121"
+         offset="0"
+         style="stop-color: rgb(211, 97, 24); stop-opacity: 1;" />
+      <stop
+         id="stop10123"
+         offset="1"
+         style="stop-color: rgb(240, 158, 111); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15606-1"
+       id="linearGradient54883-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25781212,0,0,0.3314732,631.71857,-405.51172)"
+       x1="812"
+       y1="-1075.6378"
+       x2="812"
+       y2="-1115.6378" />
+    <linearGradient
+       id="linearGradient15606-1">
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
+         offset="0"
+         id="stop15608-0" />
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
+         offset="1"
+         id="stop15610-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13785"
+       id="linearGradient54879-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4296876,0,0,0.55245533,673.68086,-225.27096)"
+       x1="370"
+       y1="-1048.6724"
+       x2="370"
+       y2="-918.60181" />
+    <linearGradient
+       id="linearGradient13785"
+       inkscape:collect="always">
+      <stop
+         id="stop13787"
+         offset="0"
+         style="stop-color: rgb(163, 62, 3); stop-opacity: 1;" />
+      <stop
+         id="stop13789"
+         offset="1"
+         style="stop-color: rgb(98, 37, 2); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient13785"
+       id="linearGradient54875-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4296876,0,0,0.55245533,673.68086,-221.95624)"
+       x1="370"
+       y1="-1048.6724"
+       x2="370"
+       y2="-918.60181" />
+    <linearGradient
+       x2="47"
+       x1="1"
+       gradientTransform="matrix(0,-0.27020355,0.27020355,0,-224.48518,130.38778)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3083-06-0-4">
+      <stop
+         id="stop7092-4-6-37"
+         style="stop-color:#e4e4e4;stop-opacity:1" />
+      <stop
+         id="stop7094-6-2-1"
+         style="stop-color:#eee;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="11.313709"
+     inkscape:cx="12.554672"
+     inkscape:cy="23.238462"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="999"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata9199">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(224.21496,-117.68776)">
+    <g
+       style="display:inline"
+       id="g7105-2-9-3"
+       transform="matrix(0.27020353,0,0,0.27020353,-224.48517,117.418)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 36.31,5 c 5.859,4.062 9.688,10.831 9.688,18.5 0,12.426 -10.07,22.5 -22.5,22.5 -7.669,0 -14.438,-3.828 -18.5,-9.688 1.037,1.822 2.306,3.499 3.781,4.969 4.085,3.712 9.514,5.969 15.469,5.969 12.703,0 23,-10.298 23,-23 0,-5.954 -2.256,-11.384 -5.969,-15.469 C 39.81,7.306 38.132,6.037 36.31,5 Z m 4.969,3.781 c 3.854,4.113 6.219,9.637 6.219,15.719 0,12.703 -10.297,23 -23,23 -6.081,0 -11.606,-2.364 -15.719,-6.219 4.16,4.144 9.883,6.719 16.219,6.719 12.703,0 23,-10.298 23,-23 0,-6.335 -2.575,-12.06 -6.719,-16.219 z"
+         style="opacity:0.05"
+         id="path7099-58-9-8" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 41.28,8.781 c 3.712,4.085 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 -5.954,0 -11.384,-2.256 -15.469,-5.969 4.113,3.854 9.637,6.219 15.719,6.219 12.703,0 23,-10.298 23,-23 0,-6.081 -2.364,-11.606 -6.219,-15.719 z"
+         style="opacity:0.1"
+         id="path7101-6-0-0" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 31.25,2.375 C 39.865,5.529 46,13.792 46,23.505 c 0,12.426 -10.07,22.5 -22.5,22.5 -9.708,0 -17.971,-6.135 -21.12,-14.75 a 23,23 0 0 0 44.875,-7 23,23 0 0 0 -16,-21.875 z"
+         style="opacity:0.2"
+         id="path7103-28-8-9" />
     </g>
-   </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -219.66365,117.91625 c -3.21435,8.31443 -1.60718,4.15706 0,0 z m 0,0 c -2.62422,0.72739 -4.55131,3.13056 -4.55131,5.98773 0,3.43236 2.78228,6.21465 6.21468,6.21465 2.85605,0 5.25923,-1.92684 5.98771,-4.55127 z m 7.65027,7.65027 c -8.31444,3.21434 -4.15708,1.60717 0,0 z"
+       style="display:inline;fill:url(#linearGradient3083-06-0-4);fill-opacity:1;stroke-width:0.27020356"
+       id="path7109-4-1-7" />
+    <g
+       style="display:inline"
+       id="g24414"
+       transform="matrix(0.39689246,0,0,0.39689246,-549.46936,429.10348)">
+      <rect
+         rx="2.2098212"
+         ry="2.2098212"
+         style="display:inline;overflow:visible;visibility:visible;fill:#a33e03;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.10491073;marker:none"
+         id="rect7488-5"
+         width="17.678581"
+         height="15.468748"
+         x="826.03571"
+         y="-776.42126" />
+      <rect
+         y="-775.31635"
+         x="827.14062"
+         height="13.258947"
+         width="15.46875"
+         id="rect7490-1"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54886-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.10491073;marker:none"
+         rx="1.1049106"
+         ry="1.1049106" />
+      <rect
+         y="-775.31635"
+         x="827.14062"
+         height="13.258947"
+         width="15.46875"
+         id="rect7494-7"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54883-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.10491073;marker:none"
+         rx="1.1049106"
+         ry="1.1049106" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#d36118;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.53695059;marker:none"
+         id="rect7496-4"
+         width="11.049108"
+         height="2.2098215"
+         x="829.3504"
+         y="-773.10657" />
+      <rect
+         y="-769.79181"
+         x="832.66522"
+         height="2.2098215"
+         width="7.734375"
+         id="rect7498-1"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54879-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.53695059;marker:none" />
+      <ellipse
+         ry="1.1049099"
+         rx="1.1049092"
+         cy="-768.68744"
+         cx="830.45563"
+         style="display:inline;overflow:visible;visibility:visible;fill:#d36118;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.20562018;marker:none"
+         id="path7500-7" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54875-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.53695059;marker:none"
+         id="rect7536-1"
+         width="7.734375"
+         height="2.2098215"
+         x="832.66522"
+         y="-766.47711" />
+      <ellipse
+         ry="1.1049099"
+         rx="1.1049092"
+         cy="-765.37268"
+         cx="830.45563"
+         id="path7538-1"
+         style="display:inline;overflow:visible;visibility:visible;fill:#d36118;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.20562018;marker:none" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -218.00028,117.6882 c -0.57635,0 -1.13378,0.0811 -1.66337,0.22805 l 7.65026,7.65027 c 0.14671,-0.52961 0.22805,-1.08622 0.22805,-1.66338 0,-3.4324 -2.78228,-6.21465 -6.21467,-6.21465 z"
+       style="display:inline;fill:#7a2e02;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.27020356"
+       id="path7107-7-3-9" />
+    <g
+       style="display:inline"
+       id="g7113-2-1-93"
+       transform="matrix(0.27020353,0,0,0.27020353,-224.48517,117.418)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 40.03,7.531 c 3.712,4.084 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 C 17.045,46 11.615,43.744 7.53,40.031 11.708,44.322 17.54,47 23.999,47 c 12.703,0 23,-10.298 23,-23 0,-6.462 -2.677,-12.291 -6.969,-16.469 z"
+         style="opacity:0.1"
+         id="path7111-4-1-2" />
+    </g>
   </g>
- </g>
- <g>
-  <g>
-   <!-- color: #f7883d -->
-   <g>
-    <path d="m 12 13 24 0 0 22 -24 0 m 0 -22" style="fill:#ececec;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 11.883,12 24.23,0 C 36.601,12 37,12.398 37,12.887 l 0,0.227 c 0,0.488 -0.398,0.887 -0.887,0.887 l -24.23,0 C 11.395,14.001 11,13.603 11,13.114 l 0,-0.227 C 11,12.399 11.395,12 11.883,12 m 0,0" style="fill:#585a61;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 11.883,34 24.23,0 C 36.601,34 37,34.398 37,34.887 l 0,0.227 c 0,0.488 -0.398,0.887 -0.887,0.887 l -24.23,0 C 11.395,36.001 11,35.603 11,35.114 l 0,-0.227 C 11,34.399 11.395,34 11.883,34 m 0,0" style="fill:#585a61;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 32 24 c 0 4.418 -3.582 8 -8 8 -4.418 0 -8 -3.582 -8 -8 0 -4.418 3.582 -8 8 -8 4.418 0 8 3.582 8 8 m 0 0" style="fill:#7fb9cf;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 29.22 17.938 -5.219 6.06 5.652 5.652 c 1.449 -1.449 2.344 -3.445 2.344 -5.652 0 -2.426 -1.082 -4.598 -2.781 -6.06 m 0.004 0" style="fill:#ff7e27;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 24,16 c -0.887,0 -1.738,0.137 -2.535,0.406 L 24,24.004 29.219,17.944 C 27.821,16.733 25.992,16.003 24,16.003 m 0,0" style="fill:#ffcfa1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-   </g>
-  </g>
- </g>
- <g>
-  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
- </g>
 </svg>


### PR DESCRIPTION
LibreOffice Impress circle icon consistent with [look and feel of oficial branding](https://wiki.documentfoundation.org/Visual_Elements). So people will recognize it more easily.

The icon is based on libreoffice-main.svg file and mixed with [oficial graphical elements and color pallete](https://wiki.documentfoundation.org/File:LibreOffice_Initial_Icons-pre_final.svg).

![proposal-libreoffice-impress](https://user-images.githubusercontent.com/6515809/31469797-691b1006-aea0-11e7-8f82-7c6ff1493b23.png)
