### PR TITLE
LibreOffice Draw circle icon consistent with oficial branding

### DIFF
--- a/icons/circle/48/libreoffice-draw.svg
+++ b/icons/circle/48/libreoffice-draw.svg
@@ -1,43 +1,237 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
- <defs>
-  <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-   <stop style="stop-color:#b0e648;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#b9e85a;stop-opacity:1"/>
-  </linearGradient>
- </defs>
- <g>
-  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
-  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
-  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
- </g>
- <g>
-  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3764);fill-opacity:1"/>
- </g>
- <g>
-  <g>
-   <g transform="translate(1,1)">
-    <g style="opacity:0.1">
-     <!-- color: #b9e85a -->
-     <g>
-      <path d="m 25 10 c -0.551 0 -1 0.449 -1 1 0.046 1.014 0.02 2.07 0.02 3.098 c -2.292 0.456 -4.02 2.476 -4.02 4.902 c 0 0.575 0.116 1.119 0.295 1.633 l -6.295 19.367 8.762 -16.551 c 0.676 0.341 1.429 0.551 2.238 0.551 c 0.808 0 1.562 -0.21 2.238 -0.551 l 8.762 16.551 -6.293 -19.373 c 0.177 -0.512 0.293 -1.054 0.293 -1.627 0 -2.412 -1.711 -4.423 -3.98 -4.895 0 -1.169 0.012 -1.938 -0.02 -3.105 0 -0.551 -0.449 -1 -1 -1 m 0 6 c 1.656 0 3 1.34 3 3 0 1.66 -1.344 3 -3 3 -1.66 0 -3 -1.34 -3 -3 0 -1.66 1.344 -3 3 -3 z" transform="translate(-1,-1)"/>
-     </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg8525"
+   inkscape:version="0.92.2 (unknown)"
+   sodipodi:docname="libreoffice-draw.svg">
+  <defs
+     id="defs8519">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6989-5"
+       id="linearGradient7415"
+       gradientUnits="userSpaceOnUse"
+       x1="1180.158"
+       y1="688.52631"
+       x2="1180.158"
+       y2="658.13159" />
+    <linearGradient
+       id="linearGradient6989-5">
+      <stop
+         id="stop6991-5"
+         offset="0"
+         style="stop-color: rgb(240, 158, 111); stop-opacity: 1;" />
+      <stop
+         id="stop6993-1"
+         offset="1"
+         style="stop-color: rgb(249, 207, 181); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6975-88"
+       id="linearGradient7417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.680908,0,0,0.644974,208.441,-1341.36)"
+       x1="1162.5912"
+       y1="901.15546"
+       x2="1162.5912"
+       y2="887.43439" />
+    <linearGradient
+       id="linearGradient6975-88">
+      <stop
+         id="stop6977-8"
+         offset="0"
+         style="stop-color: rgb(245, 206, 83); stop-opacity: 1;" />
+      <stop
+         id="stop6979-6"
+         offset="1"
+         style="stop-color: rgb(253, 233, 169); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       x2="47"
+       x1="1"
+       gradientTransform="matrix(0,-0.27021576,0.27021576,0,-199.53873,127.36396)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3083-06-0-3">
+      <stop
+         id="stop7092-4-6-6"
+         style="stop-color:#e4e4e4;stop-opacity:1" />
+      <stop
+         id="stop7094-6-2-7"
+         style="stop-color:#eee;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="-0.54787852"
+     inkscape:cy="33.470483"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="999"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata8522">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(199.26854,-114.66395)">
+    <g
+       style="display:inline"
+       id="g7105-2-9-5"
+       transform="matrix(0.27021577,0,0,0.27021577,-199.53874,114.3936)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 36.31,5 c 5.859,4.062 9.688,10.831 9.688,18.5 0,12.426 -10.07,22.5 -22.5,22.5 -7.669,0 -14.438,-3.828 -18.5,-9.688 1.037,1.822 2.306,3.499 3.781,4.969 4.085,3.712 9.514,5.969 15.469,5.969 12.703,0 23,-10.298 23,-23 0,-5.954 -2.256,-11.384 -5.969,-15.469 C 39.81,7.306 38.132,6.037 36.31,5 Z m 4.969,3.781 c 3.854,4.113 6.219,9.637 6.219,15.719 0,12.703 -10.297,23 -23,23 -6.081,0 -11.606,-2.364 -15.719,-6.219 4.16,4.144 9.883,6.719 16.219,6.719 12.703,0 23,-10.298 23,-23 0,-6.335 -2.575,-12.06 -6.719,-16.219 z"
+         style="opacity:0.05"
+         id="path7099-58-9-35" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 41.28,8.781 c 3.712,4.085 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 -5.954,0 -11.384,-2.256 -15.469,-5.969 4.113,3.854 9.637,6.219 15.719,6.219 12.703,0 23,-10.298 23,-23 0,-6.081 -2.364,-11.606 -6.219,-15.719 z"
+         style="opacity:0.1"
+         id="path7101-6-0-6" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 31.25,2.375 C 39.865,5.529 46,13.792 46,23.505 c 0,12.426 -10.07,22.5 -22.5,22.5 -9.708,0 -17.971,-6.135 -21.12,-14.75 a 23,23 0 0 0 44.875,-7 23,23 0 0 0 -16,-21.875 z"
+         style="opacity:0.2"
+         id="path7103-28-8-2" />
     </g>
-   </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -194.717,114.89188 c -3.21451,8.31479 -1.60726,4.15725 0,0 z m 0,0 c -2.62433,0.72741 -4.55154,3.13071 -4.55154,5.98799 0,3.43252 2.78243,6.21495 6.215,6.21495 2.85616,0 5.25944,-1.92694 5.98798,-4.55149 z m 7.65061,7.65061 c -8.31481,3.2145 -4.15725,1.60724 0,0 z"
+       style="display:inline;fill:url(#linearGradient3083-06-0-3);fill-opacity:1;stroke-width:0.27021578"
+       id="path7109-4-1-91" />
+    <g
+       style="display:inline"
+       id="g12743-6"
+       transform="matrix(0.43767515,0,0,0.43767515,-631.71757,456.08781)">
+      <circle
+         inkscape:export-ydpi="90"
+         inkscape:export-xdpi="90"
+         inkscape:export-filename="path12513.png"
+         transform="matrix(0.272727,0,0,0.272727,675.955,-951.865)"
+         id="path12572-2"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient7415);fill-opacity:1;fill-rule:nonzero;stroke:#a33e03;stroke-width:3.66666007;marker:none"
+         cx="1184.5"
+         cy="675.5"
+         r="16.5" />
+      <circle
+         inkscape:export-ydpi="90"
+         inkscape:export-xdpi="90"
+         inkscape:export-filename="path12513.png"
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.94117999;marker:none"
+         id="path12574-6"
+         transform="matrix(0.181818,0,0,0.181818,783.636,-890.456)"
+         cx="1184.5"
+         cy="675.5"
+         r="16.5" />
+      <rect
+         inkscape:export-ydpi="90"
+         inkscape:export-xdpi="90"
+         inkscape:export-filename="path12513.png"
+         transform="scale(1,-1)"
+         y="763.13782"
+         x="1002.5"
+         height="5.9999828"
+         width="7.0000014"
+         id="rect12576-1"
+         style="display:inline;overflow:visible;visibility:visible;fill:#c99c00;fill-opacity:1;fill-rule:nonzero;stroke:#876900;stroke-width:0.99999899;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient7417);fill-opacity:1;fill-rule:nonzero;stroke:#876900;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         d="m 1005.5,-760.13778 h -11 l 5,-9 z"
+         id="path12580-8"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <path
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#f5ce53;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.85005301;marker:none"
+         d="m 1003,-761.6378 h -6 l 2.5,-5 z"
+         id="path12584-7"
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:#92e285;fill-opacity:1;fill-rule:nonzero;stroke:#18a303;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="rect12598-9"
+         width="2"
+         height="2"
+         x="998.5"
+         y="-769.13782"
+         inkscape:export-filename="path12513.png"
+         inkscape:export-xdpi="90"
+         inkscape:export-ydpi="90" />
+      <rect
+         inkscape:export-ydpi="90"
+         inkscape:export-xdpi="90"
+         inkscape:export-filename="path12513.png"
+         y="-761.13782"
+         x="1003.5"
+         height="2"
+         width="2"
+         id="rect12600-2"
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:#92e285;fill-opacity:1;fill-rule:nonzero;stroke:#18a303;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;opacity:0.75;fill:#92e285;fill-opacity:1;fill-rule:nonzero;stroke:#18a303;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         id="rect12602-0"
+         width="2"
+         height="2"
+         x="994.5"
+         y="-761.13782"
+         inkscape:export-filename="path12513.png"
+         inkscape:export-xdpi="90"
+         inkscape:export-ydpi="90" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -193.05354,114.66381 c -0.57641,0 -1.13382,0.0811 -1.66346,0.22807 l 7.65061,7.65061 c 0.14671,-0.52964 0.22806,-1.08627 0.22806,-1.66346 0,-3.43256 -2.78243,-6.21493 -6.21494,-6.21493 z"
+       style="display:inline;fill:#9f7c00;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.27021578"
+       id="path7107-7-3-2" />
+    <g
+       style="display:inline"
+       id="g7113-2-1-7"
+       transform="matrix(0.27021577,0,0,0.27021577,-199.53874,114.3936)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 40.03,7.531 c 3.712,4.084 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 C 17.045,46 11.615,43.744 7.53,40.031 11.708,44.322 17.54,47 23.999,47 c 12.703,0 23,-10.298 23,-23 0,-6.462 -2.677,-12.291 -6.969,-16.469 z"
+         style="opacity:0.1"
+         id="path7111-4-1-0" />
+    </g>
   </g>
- </g>
- <g>
-  <g>
-   <!-- color: #b9e85a -->
-   <g>
-    <path d="m 25.02 10 0 3.227 c 0 0.98 -0.445 1.773 -1 1.773 -0.551 0 -1 -0.793 -1 -1.773 l 0 -3.227 m 2 0" style="fill:#be3d27;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 25 10 c 0 0.551 -0.449 1 -1 1 -0.551 0 -1 -0.449 -1 -1 0 -0.551 0.449 -1 1 -1 0.551 0 1 0.449 1 1 m 0 0" style="fill:#be3d27;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="M 22,22 13,39 19.5,19.004 M 22,22" style="fill:#ebecf1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="M 26,22 35,39 28.504,19.004 M 26,22" style="fill:#ebecf1;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 24 13 c -2.762 0 -5 2.238 -5 5 0 2.762 2.238 5 5 5 2.758 0 5 -2.238 5 -5 0 -2.762 -2.242 -5 -5 -5 m 0 2 c 1.656 0 3 1.34 3 3 0 1.66 -1.344 3 -3 3 -1.66 0 -3 -1.34 -3 -3 0 -1.66 1.344 -3 3 -3 m 0 0" style="fill:#be3d27;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-   </g>
-  </g>
- </g>
- <g>
-  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
- </g>
 </svg>


### PR DESCRIPTION
LibreOffice Draw circle icon consistent with [look and feel of oficial branding](https://wiki.documentfoundation.org/Visual_Elements). So people will recognize it more easily.

The icon is based on libreoffice-main.svg file and mixed with [oficial graphical elements and color pallete](https://wiki.documentfoundation.org/File:LibreOffice_Initial_Icons-pre_final.svg).

![proposal-libreoffice-draw](https://user-images.githubusercontent.com/6515809/31469835-90ca0e9a-aea0-11e7-8654-ecbd25f1d95d.png)
