### PR TITLE
LibreOffice Base circle icon consistent with oficial branding

### DIFF
--- a/icons/circle/48/libreoffice-base.svg
+++ b/icons/circle/48/libreoffice-base.svg
@@ -1,48 +1,208 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
- <defs>
-  <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-   <stop style="stop-color:#9748b4;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#9e54bb;stop-opacity:1"/>
-  </linearGradient>
- </defs>
- <g>
-  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
-  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
-  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
- </g>
- <g>
-  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3764);fill-opacity:1"/>
-  <path d="m 20 1.354 c -0.336 0.059 -0.669 0.124 -1 0.197 l 0 22.449 l -18 0 c 0 0.335 0.011 0.668 0.025 1 l 17.975 0 l 0 21.449 c 0.331 0.073 0.664 0.138 1 0.197 l 0 -21.646 l 12 0 l 0 14 l 1 0 l 8.428 0 c 0.281 -0.326 0.554 -0.659 0.816 -1 l -9.244 0 l 0 -13 l 6 0 l 1 0 l 6.975 0 c 0.014 -0.332 0.025 -0.665 0.025 -1 l -7 0 l 0 -16.516 c -0.324 -0.314 -0.658 -0.617 -1 -0.912 l 0 17.428 l -19 0 l 0 -22.646 z" style="fill:#fff;fill-opacity:0.314"/>
-  <path d="m 21 1.201 c -0.336 0.044 -0.669 0.094 -1 0.152 l 0 13.04 c -3.402 0.53 -6 1.548 -6 2.732 l 0 2.5 c 0 1.185 2.598 2.318 6 2.922 l 0 1.986 c -2.601 -0.39 -4.829 -0.994 -5.559 -1.721 c -0.297 0.297 -0.441 0.608 -0.441 0.938 l 0 1.25 l -12.975 0 c 0.014 0.336 0.038 0.668 0.066 1 l 12.908 0 l 0 0.25 c 0 1.103 2.65 1.916 6 2.361 l 0 2.773 c -2.601 -0.496 -4.829 -1.223 -5.559 -1.947 c -0.297 0.297 -0.441 0.608 -0.441 0.938 l 0 2.5 c 0 1.103 2.65 2.067 6 2.623 l 0 11.148 c 0.331 0.058 0.664 0.109 1 0.152 l 0 -11.158 c 1.624 0.222 3.347 0.359 5 0.359 c 2.729 0 5.196 -0.343 7 -0.896 l 0 4.896 l 1 0 l 6.516 0 c 0.314 -0.324 0.617 -0.658 0.912 -1 l -7.428 0 l 0 -4.266 c 1.241 -0.52 2 -1.16 2 -1.859 l 0 -2.5 c 0 -0.328 -0.176 -0.64 -0.477 -0.938 c -0.338 0.337 -0.865 0.672 -1.523 0.988 l 0 -2.453 c 1.24 -0.447 2 -1.023 2 -1.723 l 0 -0.25 l 4 0 l 1 0 l 5.908 0 c 0.029 -0.332 0.052 -0.664 0.066 -1 l -5.975 0 l 0 -16.492 c -0.321 -0.353 -0.657 -0.691 -1 -1.023 l 0 17.516 l -4 0 l 0 -1.25 c 0 -0.328 -0.176 -0.64 -0.477 -0.938 c -1.273 1.27 -5.05 2.188 -9.523 2.188 c -1.588 0 -3.339 -0.121 -5 -0.326 l 0 -1.953 c 1.276 0.177 2.636 0.279 4 0.279 c 5.523 0 11 -1.648 11 -3.375 l 0 -2.5 c 0 -1.727 -5.477 -3.125 -11 -3.125 c -1.364 0 -2.724 0.088 -4 0.242 l 0 -13.04 z m 12 27.09 l 0 2.559 c -1.801 0.665 -4.267 1.152 -7 1.152 c -1.588 0 -3.339 -0.169 -5 -0.436 l 0 -2.842 c 1.624 0.175 3.347 0.277 5 0.277 c 2.729 0 5.196 -0.25 7 -0.711 z" style="fill:#000;fill-opacity:0.098"/>
- </g>
- <g>
-  <g>
-   <g transform="translate(1,1)">
-    <g style="opacity:0.1">
-     <!-- color: #9e54bb -->
-     <g>
-      <path d="m 30 18 l 1 0 l 0 1 l -1 0 m 0 -1" style="fill:#000;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-      <path d="m 30 25.02 l 1 0 l 0 1 l -1 0 m 0 -1" style="fill:#000;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-      <path d="m 30 31.996 l 1 0 l 0 1 l -1 0 m 0 -1" style="fill:#000;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-     </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg7730"
+   inkscape:version="0.92.2 (unknown)"
+   sodipodi:docname="libreoffice-base.svg">
+  <defs
+     id="defs7724">
+    <linearGradient
+       id="linearGradient15606-1">
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
+         offset="0"
+         id="stop15608-0" />
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
+         offset="1"
+         id="stop15610-5" />
+    </linearGradient>
+    <linearGradient
+       x2="47"
+       x1="1"
+       gradientTransform="matrix(0,-0.27005073,0.27005073,0,-27.937397,226.39372)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3083-06-0-03">
+      <stop
+         id="stop7092-4-6-61"
+         style="stop-color:#e4e4e4;stop-opacity:1" />
+      <stop
+         id="stop7094-6-2-0"
+         style="stop-color:#eee;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14494"
+       id="linearGradient54972-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.334262,0,0,0.351648,1208.1647,-1019.7026)"
+       x1="520.58502"
+       y1="735.05206"
+       x2="516.15179"
+       y2="720.86298" />
+    <linearGradient
+       id="linearGradient14494">
+      <stop
+         id="stop14496"
+         offset="0"
+         style="stop-color: rgb(220, 133, 233); stop-opacity: 1;" />
+      <stop
+         id="stop14498"
+         offset="1"
+         style="stop-color: rgb(242, 203, 248); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14494"
+       id="linearGradient54969-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.334262,0,0,0.351648,1208.1647,-1024.2026)"
+       x1="520.58502"
+       y1="735.05206"
+       x2="516.15179"
+       y2="720.86298" />
+    <linearGradient
+       gradientTransform="matrix(0.334262,0,0,0.351648,1208.1647,-1027.7026)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient14494"
+       id="linearGradient9342-3"
+       gradientUnits="userSpaceOnUse"
+       x1="520.58502"
+       y1="735.05206"
+       x2="516.15179"
+       y2="720.86298" />
+    <linearGradient
+       x2="47"
+       x1="1"
+       gradientTransform="matrix(0,-0.27022761,0.27022761,0,-27.938938,226.39395)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3083-06-0-2">
+      <stop
+         id="stop7092-4-6-375"
+         style="stop-color:#e4e4e4;stop-opacity:1" />
+      <stop
+         id="stop7094-6-2-9"
+         style="stop-color:#eee;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="14.336767"
+     inkscape:cy="7.3967462"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="999"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(27.668711,-213.69394)">
+    <g
+       style="display:inline"
+       id="g7105-2-9-2"
+       transform="matrix(0.27022761,0,0,0.27022761,-27.938939,213.42301)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 36.31,5 c 5.859,4.062 9.688,10.831 9.688,18.5 0,12.426 -10.07,22.5 -22.5,22.5 -7.669,0 -14.438,-3.828 -18.5,-9.688 1.037,1.822 2.306,3.499 3.781,4.969 4.085,3.712 9.514,5.969 15.469,5.969 12.703,0 23,-10.298 23,-23 0,-5.954 -2.256,-11.384 -5.969,-15.469 C 39.81,7.306 38.132,6.037 36.31,5 Z m 4.969,3.781 c 3.854,4.113 6.219,9.637 6.219,15.719 0,12.703 -10.297,23 -23,23 -6.081,0 -11.606,-2.364 -15.719,-6.219 4.16,4.144 9.883,6.719 16.219,6.719 12.703,0 23,-10.298 23,-23 0,-6.335 -2.575,-12.06 -6.719,-16.219 z"
+         style="opacity:0.05"
+         id="path7099-58-9-2" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 41.28,8.781 c 3.712,4.085 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 -5.954,0 -11.384,-2.256 -15.469,-5.969 4.113,3.854 9.637,6.219 15.719,6.219 12.703,0 23,-10.298 23,-23 0,-6.081 -2.364,-11.606 -6.219,-15.719 z"
+         style="opacity:0.1"
+         id="path7101-6-0-8" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 31.25,2.375 C 39.865,5.529 46,13.792 46,23.505 c 0,12.426 -10.07,22.5 -22.5,22.5 -9.708,0 -17.971,-6.135 -21.12,-14.75 a 23,23 0 0 0 44.875,-7 23,23 0 0 0 -16,-21.875 z"
+         style="opacity:0.2"
+         id="path7103-28-8-97" />
     </g>
-   </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -23.11702,213.92134 c -3.2146,8.31514 -1.607279,4.15741 0,0 z m 0,0 c -2.624446,0.72743 -4.551691,3.13083 -4.551691,5.98824 0,3.43267 2.782544,6.21522 6.215215,6.21522 2.856332,0 5.259731,-1.92702 5.988253,-4.5517 z m 7.650983,7.65094 c -8.315202,3.21464 -4.157463,1.60731 0,0 z"
+       style="display:inline;fill:url(#linearGradient3083-06-0-2);fill-opacity:1;stroke-width:0.27022767"
+       id="path7109-4-1-3" />
+    <g
+       style="display:inline"
+       id="g7521"
+       transform="matrix(0.43778788,0,0,0.43778788,-626.53511,555.53544)">
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsccc"
+         id="path9344-8"
+         d="m 1374.3735,-765.89035 v 4 c 0,1.1046 3.3579,2 7.5,2 4.1421,0 7.5,-0.8954 7.5,-2 v -4 z"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54972-7);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1;marker:none" />
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54969-4);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:1;marker:none"
+         d="m 1374.3735,-770.39035 v 4 c 0,1.1046 3.3579,2 7.5,2 4.1421,0 7.5,-0.8954 7.5,-2 v -4 z"
+         id="path9335-4"
+         sodipodi:nodetypes="ccsccc" />
+      <ellipse
+         ry="1.999998"
+         rx="7.5000038"
+         cy="-770.88965"
+         cx="1381.8765"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient9342-3);fill-opacity:1;fill-rule:nonzero;stroke:#8e03a3;stroke-width:0.99999946;marker:none"
+         id="path9337-5" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -21.453496,213.69325 c -0.576378,0 -1.133864,0.0809 -1.663524,0.22809 l 7.650983,7.65094 c 0.146705,-0.52968 0.228075,-1.08632 0.228075,-1.66353 0,-3.43272 -2.782545,-6.21521 -6.215256,-6.21521 z"
+       style="display:inline;fill:#6a027a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.27022767"
+       id="path7107-7-3-61" />
+    <g
+       style="display:inline"
+       id="g7113-2-1-2"
+       transform="matrix(0.27022761,0,0,0.27022761,-27.938939,213.42301)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 40.03,7.531 c 3.712,4.084 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 C 17.045,46 11.615,43.744 7.53,40.031 11.708,44.322 17.54,47 23.999,47 c 12.703,0 23,-10.298 23,-23 0,-6.462 -2.677,-12.291 -6.969,-16.469 z"
+         style="opacity:0.1"
+         id="path7111-4-1-9" />
+    </g>
   </g>
- </g>
- <g>
-  <g>
-   <!-- color: #9e54bb -->
-   <g>
-    <path d="m 24 13 c -5.523 0 -11 1.398 -11 3.125 l 0 2.5 c 0 1.727 5.477 3.375 11 3.375 c 5.523 0 11 -1.648 11 -3.375 l 0 -2.5 c 0 -1.727 -5.477 -3.125 -11 -3.125 m 0 0" style="fill:#ecdef8;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 25 24 c -4.477 0 -10.285 -0.918 -11.559 -2.188 c -0.297 0.297 -0.441 0.609 -0.441 0.938 l 0 2.5 c 0 1.727 6.477 2.75 12 2.75 c 5.523 0 10 -1.023 10 -2.75 l 0 -2.5 c 0 -0.328 -0.176 -0.641 -0.477 -0.938 c -1.273 1.27 -5.05 2.188 -9.523 2.188 m 0 0" style="fill:#ecdef8;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 25 31 c -4.477 0 -10.285 -1.297 -11.559 -2.563 c -0.297 0.297 -0.441 0.609 -0.441 0.938 l 0 2.5 c 0 1.727 6.477 3.125 12 3.125 c 5.523 0 10 -1.398 10 -3.125 l 0 -2.5 c 0 -0.328 -0.176 -0.641 -0.477 -0.938 c -1.273 1.266 -5.05 2.563 -9.523 2.563 m 0 0" style="fill:#ecdef8;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 30 18 l 1 0 l 0 1 l -1 0 m 0 -1" style="fill:#6184fb;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 30 25.02 l 1 0 l 0 1 l -1 0 m 0 -1" style="fill:#6184fb;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 30 31.996 l 1 0 l 0 1 l -1 0 m 0 -1" style="fill:#6184fb;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-   </g>
-  </g>
- </g>
- <g>
-  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
- </g>
 </svg>


### PR DESCRIPTION
LibreOffice Base circle icon consistent with [look and feel of oficial branding](https://wiki.documentfoundation.org/Visual_Elements). So people will recognize it more easily.

The icon is based on libreoffice-main.svg file and mixed with [oficial graphical elements and color pallete](https://wiki.documentfoundation.org/File:LibreOffice_Initial_Icons-pre_final.svg).

![proposal-libreoffice-base](https://user-images.githubusercontent.com/6515809/31469859-b2b35f20-aea0-11e7-955f-772bb1ded108.png)
