### PR TITLE
LibreOffice Math circle icon consistent with oficial branding

### DIFF
--- a/icons/circle/48/libreoffice-math.svg
+++ b/icons/circle/48/libreoffice-math.svg
@@ -1,48 +1,254 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
- <defs>
-  <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-   <stop style="stop-color:#e04c8b;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#e35e97;stop-opacity:1"/>
-  </linearGradient>
- </defs>
- <g>
-  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
-  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
-  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
- </g>
- <g>
-  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3764);fill-opacity:1"/>
- </g>
- <g>
-  <g>
-   <g transform="translate(1,1)">
-    <g style="opacity:0.1">
-     <!-- color: #e35e97 -->
-     <g>
-      <path d="m 13.887 11 l 20.227 0 c 0.492 0 0.887 0.395 0.887 0.883 l 0 24.23 c 0 0.488 -0.395 0.887 -0.887 0.887 l -20.227 0 c -0.488 0 -0.887 -0.398 -0.887 -0.887 l 0 -24.23 c 0 -0.488 0.398 -0.883 0.887 -0.883 m 0 0" style="fill:#000;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-     </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg7730"
+   inkscape:version="0.92.2 (unknown)"
+   sodipodi:docname="libreoffice-math.svg">
+  <defs
+     id="defs7724">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient15606-1"
+       id="linearGradient54821-5"
+       gradientUnits="userSpaceOnUse"
+       x1="3618.4375"
+       y1="-758.63782"
+       x2="3618.4375"
+       y2="-772.63782"
+       gradientTransform="translate(79.625002,-2.3771564)" />
+    <linearGradient
+       id="linearGradient15606-1">
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
+         offset="0"
+         id="stop15608-0" />
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
+         offset="1"
+         id="stop15610-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10292"
+       id="linearGradient11076"
+       gradientUnits="userSpaceOnUse"
+       x1="3716.1616"
+       y1="683.97705"
+       x2="3716.1616"
+       y2="705.13123" />
+    <linearGradient
+       id="linearGradient10292"
+       inkscape:collect="always">
+      <stop
+         id="stop10294"
+         offset="0"
+         style="stop-color: rgb(102, 102, 102); stop-opacity: 1;" />
+      <stop
+         id="stop10296"
+         offset="1"
+         style="stop-color: rgb(51, 51, 51); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10292"
+       id="linearGradient7656"
+       gradientUnits="userSpaceOnUse"
+       x1="3716.1616"
+       y1="685.14032"
+       x2="3716.1616"
+       y2="706.41693" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10292"
+       id="linearGradient54812-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3506.1262,-1793.3772)"
+       x1="195.75"
+       y1="1006.3704"
+       x2="195.75"
+       y2="1038.3638" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10292"
+       id="linearGradient54809-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,3901.1262,-1793.8772)"
+       x1="195.75"
+       y1="1006.8059"
+       x2="195.75"
+       y2="1038.8622" />
+    <linearGradient
+       x2="47"
+       x1="1"
+       gradientTransform="matrix(0,-0.27005073,0.27005073,0,-27.937397,226.39372)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3083-06-0-03">
+      <stop
+         id="stop7092-4-6-61"
+         style="stop-color:#e4e4e4;stop-opacity:1" />
+      <stop
+         id="stop7094-6-2-0"
+         style="stop-color:#eee;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="7.9195959"
+     inkscape:cx="47.926491"
+     inkscape:cy="18.394719"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="999"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata7727">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(27.667346,-213.69371)">
+    <g
+       style="display:inline"
+       id="g7105-2-9-6"
+       transform="matrix(0.27005073,0,0,0.27005073,-27.937397,213.43128)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 36.31,5 c 5.859,4.062 9.688,10.831 9.688,18.5 0,12.426 -10.07,22.5 -22.5,22.5 -7.669,0 -14.438,-3.828 -18.5,-9.688 1.037,1.822 2.306,3.499 3.781,4.969 4.085,3.712 9.514,5.969 15.469,5.969 12.703,0 23,-10.298 23,-23 0,-5.954 -2.256,-11.384 -5.969,-15.469 C 39.81,7.306 38.132,6.037 36.31,5 Z m 4.969,3.781 c 3.854,4.113 6.219,9.637 6.219,15.719 0,12.703 -10.297,23 -23,23 -6.081,0 -11.606,-2.364 -15.719,-6.219 4.16,4.144 9.883,6.719 16.219,6.719 12.703,0 23,-10.298 23,-23 0,-6.335 -2.575,-12.06 -6.719,-16.219 z"
+         style="opacity:0.05"
+         id="path7099-58-9-32" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 41.28,8.781 c 3.712,4.085 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 -5.954,0 -11.384,-2.256 -15.469,-5.969 4.113,3.854 9.637,6.219 15.719,6.219 12.703,0 23,-10.298 23,-23 0,-6.081 -2.364,-11.606 -6.219,-15.719 z"
+         style="opacity:0.1"
+         id="path7101-6-0-06" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 31.25,2.375 C 39.865,5.529 46,13.792 46,23.505 c 0,12.426 -10.07,22.5 -22.5,22.5 -9.708,0 -17.971,-6.135 -21.12,-14.75 a 23,23 0 0 0 44.875,-7 23,23 0 0 0 -16,-21.875 z"
+         style="opacity:0.2"
+         id="path7103-28-8-15" />
     </g>
-   </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -23.118595,213.92926 c -3.212534,8.30973 -1.606268,4.1547 0,0 z m 0,0 c -2.622729,0.72697 -4.548751,3.12881 -4.548751,5.98434 0,3.43042 2.780722,6.21113 6.211187,6.21113 2.854423,0 5.256248,-1.92574 5.984331,-4.5487 z m 7.645935,7.64593 c -8.30972,3.21254 -4.154701,1.60628 0,0 z"
+       style="display:inline;fill:url(#linearGradient3083-06-0-03);fill-opacity:1;stroke-width:0.27005076"
+       id="path7109-4-1-5" />
+    <g
+       style="display:inline"
+       id="g7667"
+       transform="matrix(0.43739733,0,0,0.43739733,-1640.6504,555.95005)">
+      <rect
+         y="-775.01501"
+         x="3693.625"
+         height="14.000002"
+         width="16"
+         id="rect8291-4"
+         style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient54821-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+         id="rect8297-4"
+         width="16"
+         height="1"
+         x="3693.625"
+         y="-762.01501" />
+      <rect
+         y="-775.01501"
+         x="3693.625"
+         height="1"
+         width="16"
+         id="rect8377-3"
+         style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+      <rect
+         transform="rotate(90)"
+         style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+         id="rect8379-0"
+         width="14"
+         height="1"
+         x="-775.01501"
+         y="-3694.625" />
+      <rect
+         y="-3709.625"
+         x="-775.01501"
+         height="1"
+         width="14"
+         id="rect8381-7"
+         style="display:inline;overflow:visible;visibility:visible;fill:#f09e6f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+         transform="rotate(90)" />
+      <g
+         transform="matrix(1.50411,0,0,1.50411,-1889.2738,-1817.5472)"
+         id="g8331-8"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:8px;font-family:Vegur;display:inline;fill:url(#linearGradient11076);fill-opacity:1;stroke:none">
+        <path
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccc"
+           id="path8333-6"
+           style="font-family:Symbol;fill:url(#linearGradient7656);fill-opacity:1"
+           d="m 3721.0651,694.44959 v 1.32969 h -0.6648 v -0.59836 h -3.6568 l -1.3962,5.91711 h -0.9308 l -1.3296,-3.32422 -0.6649,-10e-6 v -0.66485 l 1.3297,2e-5 1.0637,2.65937 1.2633,-5.31876" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;fill:none;stroke:url(#linearGradient54812-7);stroke-width:1.29999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 3706.625,-768.51499 -5,5"
+         id="path8383-8"
+         sodipodi:nodetypes="cc" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         id="path8387-8"
+         d="m 3701.625,-768.51499 5,5"
+         style="display:inline;fill:none;stroke:url(#linearGradient54809-6);stroke-width:1.29999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -21.456159,213.70133 c -0.576041,0 -1.133122,0.081 -1.662436,0.22793 l 7.645935,7.64593 c 0.146654,-0.52931 0.227925,-1.0856 0.227925,-1.66243 0,-3.43047 -2.780722,-6.21114 -6.211147,-6.21114 z"
+       style="display:inline;fill:#454545;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.27005076"
+       id="path7107-7-3-4" />
+    <g
+       style="display:inline"
+       id="g7113-2-1-76"
+       transform="matrix(0.27005073,0,0,0.27005073,-27.937397,213.43128)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 40.03,7.531 c 3.712,4.084 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 C 17.045,46 11.615,43.744 7.53,40.031 11.708,44.322 17.54,47 23.999,47 c 12.703,0 23,-10.298 23,-23 0,-6.462 -2.677,-12.291 -6.969,-16.469 z"
+         style="opacity:0.1"
+         id="path7111-4-1-5" />
+    </g>
   </g>
- </g>
- <g>
-  <g>
-   <!-- color: #e35e97 -->
-   <g>
-    <path d="m 13.887,11 20.227,0 c 0.492,0 0.887,0.395 0.887,0.883 l 0,24.23 C 35.001,36.601 34.606,37 34.114,37 L 13.887,37 C 13.399,37 13,36.602 13,36.113 l 0,-24.23 C 13,11.395 13.398,11 13.887,11 m 0,0" style="fill:#eaeaea;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 15.441,31 3.113,0 c 0.246,0 0.445,0.199 0.445,0.441 l 0,3.117 c 0,0.242 -0.199,0.441 -0.445,0.441 l -3.113,0 C 15.195,34.999 15,34.8 15,34.558 l 0,-3.117 C 15,31.199 15.195,31 15.441,31 m 0,0" style="fill:#959a9b;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 15.441,25.02 3.113,0 c 0.246,0 0.445,0.199 0.445,0.441 l 0,3.117 c 0,0.242 -0.199,0.441 -0.445,0.441 l -3.113,0 C 15.195,29.019 15,28.82 15,28.578 l 0,-3.117 c 0,-0.242 0.195,-0.441 0.441,-0.441 m 0,0" style="fill:#959a9b;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 15.441,19 3.113,0 c 0.246,0 0.445,0.199 0.445,0.441 l 0,3.117 c 0,0.242 -0.199,0.441 -0.445,0.441 l -3.113,0 C 15.195,22.999 15,22.8 15,22.558 l 0,-3.117 C 15,19.199 15.195,19 15.441,19 m 0,0" style="fill:#959a9b;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 15.441,13 17.11,0 c 0.246,0 0.445,0.199 0.445,0.441 l 0,3.117 c 0,0.242 -0.199,0.441 -0.445,0.441 l -17.11,0 C 15.195,16.999 15,16.8 15,16.558 l 0,-3.117 C 15,13.199 15.195,13 15.441,13 m 0,0" style="fill:#76a3cf;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 22.441,31 3.117,0 c 0.242,0 0.441,0.199 0.441,0.441 l 0,3.117 c 0,0.242 -0.199,0.441 -0.441,0.441 l -3.117,0 C 22.199,34.999 22,34.8 22,34.558 l 0,-3.117 C 22,31.199 22.199,31 22.441,31 m 0,0" style="fill:#959a9b;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 22.441,25.02 3.117,0 c 0.242,0 0.441,0.199 0.441,0.441 l 0,3.117 c 0,0.242 -0.199,0.441 -0.441,0.441 l -3.117,0 C 22.199,29.019 22,28.82 22,28.578 l 0,-3.117 c 0,-0.242 0.199,-0.441 0.441,-0.441 m 0,0" style="fill:#959a9b;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 22.441,19 3.117,0 c 0.242,0 0.441,0.199 0.441,0.441 l 0,3.117 c 0,0.242 -0.199,0.441 -0.441,0.441 l -3.117,0 C 22.199,22.999 22,22.8 22,22.558 l 0,-3.117 C 22,19.199 22.199,19 22.441,19 m 0,0" style="fill:#959a9b;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 29.441,19 3.113,0 c 0.246,0 0.445,0.199 0.445,0.441 l 0,3.117 c 0,0.242 -0.199,0.441 -0.445,0.441 l -3.113,0 C 29.195,22.999 29,22.8 29,22.558 l 0,-3.117 C 29,19.199 29.195,19 29.441,19 m 0,0" style="fill:#959a9b;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 29.441,25.02 3.113,0 c 0.246,0 0.445,0.199 0.445,0.441 l 0,9.113 c 0,0.246 -0.199,0.445 -0.445,0.445 l -3.113,0 C 29.195,35.019 29,34.82 29,34.574 l 0,-9.113 c 0,-0.242 0.195,-0.441 0.441,-0.441 m 0,0" style="fill:#ec7f20;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-   </g>
-  </g>
- </g>
- <g>
-  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
- </g>
 </svg>


### PR DESCRIPTION
LibreOffice Math circle icon consistent with [look and feel of oficial branding](https://wiki.documentfoundation.org/Visual_Elements). So people will recognize it more easily.

The icon is based on libreoffice-main.svg file and mixed with [oficial graphical elements and color pallete](https://wiki.documentfoundation.org/File:LibreOffice_Initial_Icons-pre_final.svg).

![proposal-libreoffice-math](https://user-images.githubusercontent.com/6515809/31469998-3e444d10-aea1-11e7-8912-9079df6ceb10.png)
