### PR TITLE
LibreOffice main circle icon consistent with oficial branding

### DIFF
--- a/icons/circle/48/libreoffice-main.svg
+++ b/icons/circle/48/libreoffice-main.svg
@@ -1,18 +1,117 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
- <defs>
-  <linearGradient id="linearGradient3083" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)" x1="1" x2="47">
-   <stop style="stop-color:#e4e4e4;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#eee;stop-opacity:1"/>
-  </linearGradient>
- </defs>
- <g>
-  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
-  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
-  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
- </g>
- <path d="m 24 1 c -2.133 0 -4.196 0.3 -6.156 0.844 l 28.313 28.313 c 0.543 -1.96 0.844 -4.02 0.844 -6.156 c 0 -12.703 -10.297 -23 -23 -23 z" style="fill:#2d2d2d;fill-opacity:1;stroke:none;fill-rule:evenodd"/>
- <path d="m 17.844 1.844 c -11.896 30.771 -5.948 15.385 0 0 z m 0 0 c -9.712 2.692 -16.844 11.586 -16.844 22.16 0 12.703 10.297 23 23 23 10.57 0 19.464 -7.131 22.16 -16.844 z m 28.313 28.313 c -30.771 11.896 -15.385 5.948 0 0 z" style="fill:url(#linearGradient3083);fill-opacity:1"/>
- <g>
-  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
- </g>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 12.7 12.7"
+   version="1.1"
+   id="svg11320"
+   inkscape:version="0.92.2 (unknown)"
+   sodipodi:docname="libreoffice-main.svg">
+  <defs
+     id="defs11314">
+    <linearGradient
+       x2="47"
+       x1="1"
+       gradientTransform="matrix(0,-0.27022097,0.27022097,0,-63.467322,39.673464)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3083-06-0">
+      <stop
+         id="stop7092-4-6"
+         style="stop-color:#e4e4e4;stop-opacity:1" />
+      <stop
+         id="stop7094-6-2"
+         style="stop-color:#eee;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="22.328049"
+     inkscape:cy="37.458164"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="999"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata11317">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(63.197108,-26.97348)">
+    <g
+       style="display:inline"
+       id="g7105-2-9"
+       transform="matrix(0.27022098,0,0,0.27022098,-63.467329,26.702874)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 36.31,5 c 5.859,4.062 9.688,10.831 9.688,18.5 0,12.426 -10.07,22.5 -22.5,22.5 -7.669,0 -14.438,-3.828 -18.5,-9.688 1.037,1.822 2.306,3.499 3.781,4.969 4.085,3.712 9.514,5.969 15.469,5.969 12.703,0 23,-10.298 23,-23 0,-5.954 -2.256,-11.384 -5.969,-15.469 C 39.81,7.306 38.132,6.037 36.31,5 Z m 4.969,3.781 c 3.854,4.113 6.219,9.637 6.219,15.719 0,12.703 -10.297,23 -23,23 -6.081,0 -11.606,-2.364 -15.719,-6.219 4.16,4.144 9.883,6.719 16.219,6.719 12.703,0 23,-10.298 23,-23 0,-6.335 -2.575,-12.06 -6.719,-16.219 z"
+         style="opacity:0.05"
+         id="path7099-58-9" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 41.28,8.781 c 3.712,4.085 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 -5.954,0 -11.384,-2.256 -15.469,-5.969 4.113,3.854 9.637,6.219 15.719,6.219 12.703,0 23,-10.298 23,-23 0,-6.081 -2.364,-11.606 -6.219,-15.719 z"
+         style="opacity:0.1"
+         id="path7101-6-0" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 31.25,2.375 C 39.865,5.529 46,13.792 46,23.505 c 0,12.426 -10.07,22.5 -22.5,22.5 -9.708,0 -17.971,-6.135 -21.12,-14.75 a 23,23 0 0 0 44.875,-7 23,23 0 0 0 -16,-21.875 z"
+         style="opacity:0.2"
+         id="path7103-28-8" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m -58.645505,27.201152 c -3.214548,8.314979 -1.607272,4.157345 0,0 z m 0,0 c -2.624388,0.727425 -4.551603,3.130781 -4.551603,5.988094 0,3.432619 2.782468,6.215075 6.215086,6.215075 2.856235,0 5.259582,-1.926934 5.988098,-4.551583 z m 7.650767,7.650768 c -8.314969,3.214557 -4.157347,1.607264 0,0 z"
+       style="display:inline;fill:url(#linearGradient3083-06-0);fill-opacity:1;stroke-width:0.27022102"
+       id="path7109-4-1" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m -56.982022,26.973088 c -0.576383,0 -1.133851,0.08105 -1.663483,0.228064 l 7.650764,7.650768 c 0.146731,-0.529635 0.228068,-1.086285 0.228068,-1.663496 0,-3.432614 -2.782463,-6.21507 -6.215078,-6.21507 z"
+       style="display:inline;fill:#454545;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.27022102"
+       id="path7107-7-3" />
+    <g
+       style="display:inline"
+       id="g7113-2-1"
+       transform="matrix(0.27022098,0,0,0.27022098,-63.467329,26.702874)">
+      <path
+         inkscape:connector-curvature="0"
+         d="m 40.03,7.531 c 3.712,4.084 5.969,9.514 5.969,15.469 0,12.703 -10.297,23 -23,23 C 17.045,46 11.615,43.744 7.53,40.031 11.708,44.322 17.54,47 23.999,47 c 12.703,0 23,-10.298 23,-23 0,-6.462 -2.677,-12.291 -6.969,-16.469 z"
+         style="opacity:0.1"
+         id="path7111-4-1" />
+    </g>
+  </g>
 </svg>


### PR DESCRIPTION
I changed a little bit the LibreOffice main circle icon. I applied a lighter gray, according to the official color palette

![proposal-libreoffice-main](https://user-images.githubusercontent.com/6515809/31470120-c023222a-aea1-11e7-8b88-de06bcfa67d3.png)
