### PR TITLE
Symlink for the icon name provided by the official Arduino installer.

### DIFF
--- a/data.json
+++ b/data.json
@@ -806,6 +806,7 @@
             "symlinks": [
                 "arduino-icon-small",
                 "arduino-ide",
+                "arduino-arduinoide",
                 "gnoduino"
             ]
         }


### PR DESCRIPTION
The Arduino installer uses what seems to be a botched name, `arduino-arduinoide`.