### PR TITLE
Don't require linux icons anymore

### DIFF
--- a/tests/schema.json
+++ b/tests/schema.json
@@ -36,10 +36,7 @@
                 }
             },
             "additionalProperties": false,
-            "minProperties": 1,
-            "required": [
-                "linux"
-            ]
+            "minProperties": 1
         }
     }
 }


### PR DESCRIPTION
As we are going to have some new android only icons this is not needed anymore
