### PR TITLE
Optimize and restructure 48px templates.

### DIFF
--- a/templates/circle/48.svg
+++ b/templates/circle/48.svg
@@ -1,103 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   viewBox="0 0 48 48"
-   id="svg25"
-   sodipodi:docname="48-2.svg"
-   inkscape:version="0.92.1 r">
-  <metadata
-     id="metadata29">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="640"
-     inkscape:window-height="480"
-     id="namedview27"
-     showgrid="true"
-     inkscape:zoom="10.812826"
-     inkscape:cx="24"
-     inkscape:cy="24"
-     inkscape:current-layer="svg25">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4506" />
-  </sodipodi:namedview>
-  <defs
-     id="defs7">
-    <linearGradient
-       id="linearGradient840"
-       x1="1"
-       x2="47"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         style="stop-color:#501616"
-         offset="0"
-         id="stop2" />
-      <stop
-         style="stop-color:#601a1a"
-         offset="1"
-         id="stop4" />
-    </linearGradient>
-  </defs>
-  <path
-     d="m36.31 5c5.859 4.062 9.688 10.831 9.688 18.5 0 12.426-10.07 22.5-22.5 22.5-7.669 0-14.438-3.828-18.5-9.688 1.037 1.822 2.306 3.499 3.781 4.969 4.085 3.712 9.514 5.969 15.469 5.969 12.703 0 23-10.298 23-23 0-5.954-2.256-11.384-5.969-15.469-1.469-1.475-3.147-2.744-4.969-3.781zm4.969 3.781c3.854 4.113 6.219 9.637 6.219 15.719 0 12.703-10.297 23-23 23-6.081 0-11.606-2.364-15.719-6.219 4.16 4.144 9.883 6.719 16.219 6.719 12.703 0 23-10.298 23-23 0-6.335-2.575-12.06-6.719-16.219z"
-     style="opacity:.05"
-     id="path9" />
-  <path
-     d="m41.28 8.781c3.712 4.085 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.113 3.854 9.637 6.219 15.719 6.219 12.703 0 23-10.298 23-23 0-6.081-2.364-11.606-6.219-15.719z"
-     style="opacity:.1"
-     id="path11" />
-  <path
-     d="m31.25 2.375c8.615 3.154 14.75 11.417 14.75 21.13 0 12.426-10.07 22.5-22.5 22.5-9.708 0-17.971-6.135-21.12-14.75a23 23 0 0 0 44.875 -7 23 23 0 0 0 -16 -21.875z"
-     style="opacity:.2"
-     id="path13" />
-  <g
-     transform="matrix(0,-1,1,0,0,48)"
-     style="fill:#501616"
-     id="g17">
-    <path
-       d="m24 1c12.703 0 23 10.297 23 23s-10.297 23-23 23-23-10.297-23-23 10.297-23 23-23z"
-       style="fill:url(#linearGradient840)"
-       id="path15" />
-  </g>
-  <path
-     d="m40.03 7.531c3.712 4.084 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.178 4.291 10.01 6.969 16.469 6.969 12.703 0 23-10.298 23-23 0-6.462-2.677-12.291-6.969-16.469z"
-     style="opacity:.1"
-     id="path19" />
-  <circle
-     cx="24"
-     cy="24"
-     r="15"
-     style="fill:#a02c2c;opacity:.9"
-     id="circle21" />
-  <rect
-     x="12.203"
-     y="12.102"
-     width="24"
-     height="24"
-     style="fill:#ff9c9c;opacity:.406"
-     id="rect23" />
+<svg version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <linearGradient id="linearGradient001" x2="0" y1="47" y2="1" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#501616" offset="0"/>
+   <stop style="stop-color:#601a1a" offset="1"/>
+  </linearGradient>
+ </defs>
+ <path d="m36.31 5c5.859 4.062 9.688 10.831 9.688 18.5 0 12.426-10.07 22.5-22.5 22.5-7.669 0-14.438-3.828-18.5-9.688 1.037 1.822 2.306 3.499 3.781 4.969 4.085 3.712 9.514 5.969 15.469 5.969 12.703 0 23-10.298 23-23 0-5.954-2.256-11.384-5.969-15.469-1.469-1.475-3.147-2.744-4.969-3.781zm4.969 3.781c3.854 4.113 6.219 9.637 6.219 15.719 0 12.703-10.297 23-23 23-6.081 0-11.606-2.364-15.719-6.219 4.16 4.144 9.883 6.719 16.219 6.719 12.703 0 23-10.298 23-23 0-6.335-2.575-12.06-6.719-16.219z" style="opacity:.05"/>
+ <path d="m41.28 8.781c3.712 4.085 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.113 3.854 9.637 6.219 15.719 6.219 12.703 0 23-10.298 23-23 0-6.081-2.364-11.606-6.219-15.719z" style="opacity:.1"/>
+ <path d="m31.25 2.375c8.615 3.154 14.75 11.417 14.75 21.13 0 12.426-10.07 22.5-22.5 22.5-9.708 0-17.971-6.135-21.12-14.75a23 23 0 0 0 44.875-7 23 23 0 0 0-16-21.875z" style="opacity:.2"/>
+ <circle cx="24" cy="24" r="23" style="fill:url(#linearGradient001)"/>
+ <path d="m40.03 7.531c3.712 4.084 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.178 4.291 10.01 6.969 16.469 6.969 12.703 0 23-10.298 23-23 0-6.462-2.677-12.291-6.969-16.469z" style="opacity:.1"/>
+ <circle cx="24" cy="24" r="15" style="fill:#a02c2c;opacity:.9"/>
+ <rect x="12" y="12" width="24" height="24" style="fill:#ff9c9c;opacity:.406"/>
 </svg>

--- a/templates/square/48.svg
+++ b/templates/square/48.svg
@@ -1,119 +1,15 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="48"
-   height="48"
-   version="1.1"
-   viewBox="0 0 48 48.000001"
-   id="svg29"
-   sodipodi:docname="48.svg"
-   inkscape:version="0.92.1 r">
-  <metadata
-     id="metadata33">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="640"
-     inkscape:window-height="480"
-     id="namedview31"
-     showgrid="true"
-     inkscape:zoom="10.812826"
-     inkscape:cx="7.3993437"
-     inkscape:cy="24"
-     inkscape:current-layer="svg29">
-    <inkscape:grid
-       type="xygrid"
-       id="grid4510" />
-  </sodipodi:namedview>
-  <defs
-     id="defs7">
-    <linearGradient
-       id="linearGradient4501"
-       x1="-47"
-       x2="-1"
-       y1="2.8779e-15"
-       y2="6.1232e-17"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         style="stop-color:#501616"
-         offset="0"
-         id="stop2" />
-      <stop
-         style="stop-color:#601a1a"
-         offset="1"
-         id="stop4" />
-    </linearGradient>
-  </defs>
-  <g
-     transform="translate(0 3.949e-5)"
-     id="g15">
-    <path
-       d="m1 43v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4zm0 0.5v0.5c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.5c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z"
-       style="opacity:.02"
-       id="path9" />
-    <path
-       d="m1 43.25v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z"
-       style="opacity:.05"
-       id="path11" />
-    <path
-       d="m1 43v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z"
-       style="opacity:.1"
-       id="path13" />
-  </g>
-  <rect
-     transform="rotate(-90)"
-     x="-47"
-     y="1"
-     width="46"
-     height="46"
-     rx="4"
-     style="fill:url(#linearGradient4501)"
-     id="rect17" />
-  <g
-     transform="translate(0 3.949e-5)"
-     id="g23">
-    <g
-       transform="translate(0 -1004.4)"
-       id="g21">
-      <path
-         d="m1 1043.4v4c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-4c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z"
-         style="opacity:.1"
-         id="path19" />
-    </g>
-  </g>
-  <circle
-     cx="24"
-     cy="23"
-     r="15"
-     style="fill:#a02c2c;opacity:.9"
-     id="circle25" />
-  <rect
-     x="12.203"
-     y="11.102"
-     width="24"
-     height="24"
-     style="fill:#ff9c9c;opacity:.406"
-     id="rect27" />
+<svg width="48" height="48" version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <linearGradient id="linearGradient001" x2="0" y1="47" y2="1" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#501616" offset="0"/>
+   <stop style="stop-color:#601a1a" offset="1"/>
+  </linearGradient>
+ </defs>
+ <path d="m1 43v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4zm0 0.5v0.5c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.5c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.02"/>
+ <path d="m1 43.25v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.05"/>
+ <path d="m1 43v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.1"/>
+ <rect x="1" y="1" width="46" height="46" rx="4" style="fill:url(#linearGradient001)"/>
+ <path d="m1 39v4c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-4c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.1"/>
+ <circle cx="24" cy="23" r="15" style="fill:#a02c2c;opacity:.9"/>
+ <rect x="12" y="11" width="24" height="24" style="fill:#ff9c9c;opacity:.406"/>
 </svg>


### PR DESCRIPTION
There is some mismatch between the structure of the circle and square templates, this PR optimizes and restructures both for the 48px size.

As is, the centre guides are [not pixel perfect](https://user-images.githubusercontent.com/11786132/34138979-f8304ff6-e4bd-11e7-9e63-4dec2f3fbd66.png), and the baseplate is unnecessarily grouped, requiring several clicks to traverse the groups to edit the gradient. [Small](https://github.com/numixproject/numix-core/pull/4028/files#diff-ee027c966d9d2191f2f972736dbb86a5L70) and [large](https://github.com/numixproject/numix-core/pull/4028/files#diff-ee027c966d9d2191f2f972736dbb86a5L98) unneeded translates are also present, along with an unneeded [rotation](https://github.com/numixproject/numix-core/pull/4028/files#diff-ee027c966d9d2191f2f972736dbb86a5L86).

I really don't see this as requiring any work on existing icons, but I would like to have it in place going forward. It *might* be possible to batch search/replace the offending sections in existing icons though, I need to look into that.