### PR TITLE
Symlink for kblogger.

### DIFF
--- a/data.json
+++ b/data.json
@@ -1339,6 +1339,7 @@
             "root": "blogger",
             "symlinks": [
                 "chrome-lejliakmhcfhakneflmicaoikhbicggc-Default",
+                "kblogger",
                 "web-blogger"
             ]
         }


### PR DESCRIPTION
For #2294

`kblogger` seems to be all but dead ([the domain](http://kblogger.pwsp.net/) for it is). I cannot even find the source code. Near as I can tell, it was last updated [over 8 years ago](https://www.linux-apps.com/content/show.php?content=29552). As such, a symlink will suffice for the 2 people still using it...