### PR TITLE
add ordered database tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.bak
 *.swp
 .vscode/
+__pycache__/*
+*.pyc
 
 # Output Directories
 numix-circle.icns/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ before_install:
     - sudo apt-get install -y python3-pip python3-gi python3-gobject gir1.2-gtk-3.0 libgtk-3-dev libgirepository1.0-dev
 install:
     - pip3 install --upgrade pip
-    - pip3 install cairosvg pep8 jsonschema
+    - pip3 install cairosvg pycodestyle jsonschema
 script:
-    - sh ./tests/pep8.sh
+    - sh ./tests/pycodestyle.sh
     - python3 ./tests/schema.py
     - python3 ./tests/db_entry.py
     - python3 ./tests/icons_entry.py
+    - python3 ./tests/ordered_db.py

--- a/data.json
+++ b/data.json
@@ -36,11 +36,6 @@
             ]
         }
     },
-    "halo": {
-        "linux": {
-            "root": "7BD8_halo.0"
-        }
-    },
     "6180-the-moon": {
         "linux": {
             "root": "steam_icon_299660"
@@ -283,6 +278,11 @@
             "root": "activity-journal"
         }
     },
+    "ad-venture-capitalist": {
+        "linux": {
+            "root": "steam_icon_346900"
+        }
+    },
     "addressbook": {
         "linux": {
             "root": "addressbook",
@@ -397,11 +397,6 @@
     "AdobeWidgetBrowser": {
         "linux": {
             "root": "AdobeWidgetBrowser"
-        }
-    },
-    "ad-venture-capitalist": {
-        "linux": {
-            "root": "steam_icon_346900"
         }
     },
     "aegisub": {
@@ -821,9 +816,9 @@
         "linux": {
             "root": "arduino",
             "symlinks": [
+                "arduino-arduinoide",
                 "arduino-icon-small",
                 "arduino-ide",
-                "arduino-arduinoide",
                 "gnoduino"
             ]
         }
@@ -1370,7 +1365,6 @@
     "blueprint_tycoon": {
         "linux": {
             "root": "steam_icon_454060"
-
         }
     },
     "blueradio": {
@@ -2417,7 +2411,7 @@
         "linux": {
             "root": "chrome-bikioccmkafdpakkkcpdbppfkghcmihk-Default",
             "symlinks": [
-                "signal-desktop"   
+                "signal-desktop"
             ]
         }
     },
@@ -6550,6 +6544,11 @@
     "haguichi": {
         "linux": {
             "root": "haguichi"
+        }
+    },
+    "halo": {
+        "linux": {
+            "root": "7BD8_halo.0"
         }
     },
     "hammerfight": {
@@ -10982,17 +10981,17 @@
             "root": "puddletag"
         }
     },
+    "pulse-secure": {
+        "linux": {
+            "root": "pulse-secure"
+        }
+    },
     "pulseeffects": {
         "linux": {
             "root": "pulseeffects",
             "symlinks": [
                 "com.github.wwmm.pulseeffects"
             ]
-        }
-    },
-    "pulse-secure": {
-        "linux": {
-            "root": "pulse-secure"
         }
     },
     "pumpa": {
@@ -12227,6 +12226,11 @@
             ]
         }
     },
+    "semaphor": {
+        "linux": {
+            "root": "semaphor"
+        }
+    },
     "sencha-animator": {
         "linux": {
             "root": "sencha-animator"
@@ -12258,11 +12262,6 @@
             "symlinks": [
                 "setBfree"
             ]
-        }
-    },
-    "semaphor": {
-        "linux": {
-            "root": "semaphor"
         }
     },
     "setroubleshoot_icon": {
@@ -12760,6 +12759,11 @@
             "root": "stacer"
         }
     },
+    "star-uml": {
+        "linux": {
+            "root": "staruml"
+        }
+    },
     "starcraft-2": {
         "linux": {
             "root": "starcraft-2",
@@ -12790,11 +12794,6 @@
             "symlinks": [
                 "gog-stargunner"
             ]
-        }
-    },
-    "star-uml": {
-        "linux": {
-            "root": "staruml"
         }
     },
     "steadyflow": {
@@ -13298,14 +13297,14 @@
             "root": "steam_icon_290930"
         }
     },
-    "steam_icon_292910": {
-        "linux": {
-            "root": "steam_icon_292910"
-        }
-    },
     "steam_icon_292600": {
         "linux": {
             "root": "steam_icon_292600"
+        }
+    },
+    "steam_icon_292910": {
+        "linux": {
+            "root": "steam_icon_292910"
         }
     },
     "steam_icon_293780": {
@@ -16084,9 +16083,9 @@
         "linux": {
             "root": "youtube-dl",
             "symlinks": [
+                "com.github.JannikHv.Gydl",
                 "com.github.robertsanseries.karim",
                 "gydl",
-                "com.github.JannikHv.Gydl",
                 "youtube-dl-gui",
                 "youtube-dl-gui_48x48",
                 "youtube-dl-qt-icon",

--- a/tests/db_entry.py
+++ b/tests/db_entry.py
@@ -11,6 +11,8 @@
 from os import path
 import json
 
+from utils import error
+
 ABS_PATH = path.dirname(path.abspath(__file__))
 DB_FILE = path.join(ABS_PATH, "../data.json")
 THEMES = ["circle", "square"]
@@ -25,8 +27,8 @@ with open(DB_FILE, 'r') as db_obj:
             icon = path.join(ICONS_DIR, theme, "48/{}.svg".format(entry))
             if not path.exists(icon):
                 has_errors = True
-                print("\033[91m The icon {} doesn't exist"
-                      " in the theme {} \033[0m".format(
+                error("The icon {} doesn't exist"
+                      " in the theme {}".format(
                           entry, theme
                       ))
 exit(int(has_errors))

--- a/tests/icons_entry.py
+++ b/tests/icons_entry.py
@@ -11,6 +11,8 @@ from glob import glob
 from os import path
 import json
 
+from utils import error
+
 ABS_PATH = path.dirname(path.abspath(__file__))
 DB_FILE = path.join(ABS_PATH, "../data.json")
 THEMES = ["circle", "square"]
@@ -29,8 +31,8 @@ for theme in THEMES:
         if icon_name not in entries and icon_name not in reported:
             reported.append(icon_name)
             has_errors = True
-            print("\033[91m The icon {} doesn't have any "
-                  "entry in the database \033[0m".format(
+            error("The icon {} doesn't have any "
+                  "entry in the database.".format(
                       icon_name
                   ))
 exit(int(has_errors))

--- a/tests/ordered_db.py
+++ b/tests/ordered_db.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+# Copyright (C) 2016
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (version 3+) as
+# published by the Free Software Foundation. You should have received
+# a copy of the GNU General Public License along with this program.
+# If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from os import path
+import json
+from collections import OrderedDict
+
+from utils import sort, error
+
+
+ABS_PATH = path.dirname(path.abspath(__file__))
+DB_FILE = path.realpath(path.join(ABS_PATH, "../data.json"))
+
+
+with open(DB_FILE, 'r') as db_obj:
+    data = json.load(db_obj, object_pairs_hook=OrderedDict)
+
+keys = list(data.keys())
+ordreded_keys = sort(keys)
+has_errors = False
+
+for i in range(len(keys)):
+    if keys[i] != ordreded_keys[i]:
+        correct_position = ordreded_keys.index(keys[i])
+        has_errors = True
+        error("Database entry {} not correctly "
+              "ordred".format(keys[i]))
+        print("Should be placed at {} instead "
+              "of {}".format(correct_position, i))
+
+
+for key, value in data.items():
+    if value.get("linux"):
+        symlinks = value["linux"].get("symlinks")
+        if symlinks:
+            ordered_symlinks = sort(symlinks)
+            for i in range(len(symlinks)):
+                if symlinks[i] != ordered_symlinks[i]:
+                    has_errors = True
+                    error("Linux symlink of \"{}\" not correctly "
+                          "ordered: {}".format(key, symlinks[i]))
+    if value.get("android"):
+        android_icons = value["android"]
+        ordered_and_icons = sort(android_icons)
+        for i in range(len(android_icons)):
+            if android_icons[i] != ordered_and_icons[i]:
+                has_errors = True
+                error("Android Icon \"{}\" not correctly "
+                      "ordered".format(android_icons[i]))
+exit(int(has_errors))

--- a/tests/pep8.sh
+++ b/tests/pep8.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-find . -name "*.py" | xargs pep8 $1

--- a/tests/pycodestyle.sh
+++ b/tests/pycodestyle.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+find . -name "*.py" | xargs pycodestyle $1

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -14,6 +14,8 @@ from os import path
 from jsonschema import validate, ValidationError
 from jsonschema.exceptions import SchemaError as SchemaError
 
+from utils import error, success
+
 DB_FILE = path.join(path.dirname(path.abspath(__file__)), "../data.json")
 SCHEMA_FILE = path.join(path.dirname(path.abspath(__file__)), 'schema.json')
 
@@ -26,8 +28,8 @@ with open(DB_FILE, 'r') as db_obj:
         validate(json.load(db_obj), SCHEMA)
     except (ValidationError, ValueError, SchemaError) as error:
         has_errors = True
-        print("\033[91m Invalid database \033[0m")
-        print("\033[91m {}\033[0m".format(error))
+        error("Invalid database")
+        error("{}".format(error))
     else:
-        print("\033[92m The database is valid\033[0m")
+        success("The database is valid")
 exit(int(has_errors))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""
+# Copyright (C) 2016
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (version 3+) as
+# published by the Free Software Foundation. You should have received
+# a copy of the GNU General Public License along with this program.
+# If not, see <http://www.gnu.org/licenses/>.
+"""
+
+
+def sort(icons_list):
+    """Sort list case insensitive."""
+    return sorted(icons_list,
+                  key=lambda icon_name: icon_name.lower())
+
+
+def error(msg):
+    """Print an error msg: Red color."""
+    print("\033[91m{}\033[0m".format(msg))
+
+
+def success(msg):
+    """Print a success msg: Green color."""
+    print("\033[92m{}\033[0m".format(msg))


### PR DESCRIPTION
This PR does few things:

- Replace pep8 with pycodestyle. As the first one was renamed.
```shell
pep8 has been renamed to pycodestyle (GitHub issue #466)
Use of the pep8 tool will be removed in a future release.
Please install and use `pycodestyle` instead.

$ pip install pycodestyle
$ pycodestyle ...
```
- Create an `utils` file where I put the functions that are shared btw all the tests files.
- Provide the ordered database tests.
Here's how it looks like currently.
```shell
Database entry halo not correctly ordred
Should be placed at 992 instead of 5
Database entry 6180-the-moon not correctly ordred
Should be placed at 5 instead of 6
Database entry 7zip not correctly ordred
Should be placed at 6 instead of 7
Database entry 8-ball-pool not correctly ordred
Should be placed at 7 instead of 8
Database entry 9AD6_Origin.0 not correctly ordred
Should be placed at 8 instead of 9
.....
.....
Should be placed at 982 instead of 983
Database entry gummi not correctly ordred
Should be placed at 983 instead of 984
Database entry gv not correctly ordred
Should be placed at 984 instead of 985
Database entry gwc not correctly ordred
Should be placed at 985 instead of 986
Database entry gweled not correctly ordred
Should be placed at 986 instead of 987
Database entry gwoffice not correctly ordred
Should be placed at 987 instead of 988
Database entry gx_head not correctly ordred
Should be placed at 988 instead of 989
Database entry gyazo not correctly ordred
Should be placed at 989 instead of 990
Database entry hacknet not correctly ordred
Should be placed at 990 instead of 991
Database entry haguichi not correctly ordred
Should be placed at 991 instead of 992
Database entry pulseeffects not correctly ordred
Should be placed at 1638 instead of 1637
Database entry pulse-secure not correctly ordred
Should be placed at 1637 instead of 1638
Database entry sencha-animator not correctly ordred
Should be placed at 1836 instead of 1835
Database entry serialplot not correctly ordred
Should be placed at 1837 instead of 1836
Database entry session-properties not correctly ordred
Should be placed at 1838 instead of 1837
Database entry setbfree not correctly ordred
Should be placed at 1839 instead of 1838
Database entry semaphor not correctly ordred
Should be placed at 1835 instead of 1839
Database entry starcraft-2 not correctly ordred
Should be placed at 1917 instead of 1916
Database entry stardew_valley not correctly ordred
Should be placed at 1918 instead of 1917
Database entry stardict not correctly ordred
Should be placed at 1919 instead of 1918
Database entry starfighter not correctly ordred
Should be placed at 1920 instead of 1919
Database entry star-uml not correctly ordred
Should be placed at 1916 instead of 1920
Database entry steam_icon_292910 not correctly ordred
Should be placed at 2016 instead of 2015
Database entry steam_icon_292600 not correctly ordred
Should be placed at 2015 instead of 2016
Linux symlink of "arduino" not correctly ordered: arduino-icon-small
Linux symlink of "arduino" not correctly ordered: arduino-ide
Linux symlink of "arduino" not correctly ordered: arduino-arduinoide
Linux symlink of "youtube-dl" not correctly ordered: com.github.robertsanseries.karim
Linux symlink of "youtube-dl" not correctly ordered: gydl
Linux symlink of "youtube-dl" not correctly ordered: com.github.JannikHv.Gydl
```

I will re-order the database file within the same PR 
