### PR TITLE
Add icon cache test for linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ script:
     - python3 ./tests/db_entry.py
     - python3 ./tests/icons_entry.py
     - python3 ./tests/ordered_db.py
+    - python3 ./tests/icon_cache.py

--- a/data.json
+++ b/data.json
@@ -516,7 +516,7 @@
     },
     "amazon-store": {
         "android": [
-            "com.amazon.mShop.android.shopping"  
+            "com.amazon.mShop.android.shopping"
         ],
         "linux": {
             "root": "amazon-store",
@@ -4923,7 +4923,7 @@
     },
     "file-manager": {
         "android": [
-            "com.amaze.filemanager"  
+            "com.amaze.filemanager"
         ],
         "linux": {
             "root": "file-manager",
@@ -5049,7 +5049,7 @@
     },
     "firefox-beta": {
         "android": [
-            "org.mozilla.firefox_beta"  
+            "org.mozilla.firefox_beta"
         ],
         "linux": {
             "root": "firefox-beta",
@@ -5597,7 +5597,7 @@
     },
     "gcolor2": {
         "android": [
-            "ch.ihdg.calendarcolor"  
+            "ch.ihdg.calendarcolor"
         ],
         "linux": {
             "root": "gcolor2",
@@ -6124,7 +6124,7 @@
         "linux": {
             "root": "gnome-multi-writer",
             "symlinks": [
-                "org.gnome.MultiWriter"   
+                "org.gnome.MultiWriter"
             ]
         }
     },
@@ -9491,7 +9491,7 @@
     },
     "ms-onenote": {
         "android": [
-            "com.microsoft.office.onenote"  
+            "com.microsoft.office.onenote"
         ],
         "linux": {
             "root": "ms-onenote",
@@ -10210,7 +10210,7 @@
     },
     "onedrive": {
         "android": [
-            "om.microsoft.skydrive"  
+            "om.microsoft.skydrive"
         ],
         "linux": {
             "root": "onedrive",
@@ -12959,7 +12959,7 @@
     },
     "skype": {
         "android": [
-            "com.skype.raider"  
+            "com.skype.raider"
         ],
         "linux": {
             "root": "skype",
@@ -13358,10 +13358,7 @@
     },
     "starcraft-2": {
         "linux": {
-            "root": "starcraft-2",
-            "symlinks": [
-                "924C_StarCraft II.0"
-            ]
+            "root": "starcraft-2"
         }
     },
     "stardew_valley": {
@@ -15589,7 +15586,7 @@
     },
     "vlc": {
         "android": [
-            "org.videolan.vlc"  
+            "org.videolan.vlc"
         ],
         "linux": {
             "root": "vlc",

--- a/tests/icon_cache.py
+++ b/tests/icon_cache.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""
+# Copyright (C) 2016
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License (version 3+) as
+# published by the Free Software Foundation. You should have received
+# a copy of the GNU General Public License along with this program.
+# If not, see <http://www.gnu.org/licenses/>.
+"""
+from os import path
+import json
+from collections import OrderedDict
+
+from utils import error
+
+ABS_PATH = path.dirname(path.abspath(__file__))
+DB_FILE = path.join(ABS_PATH, "../data.json")
+
+with open(DB_FILE, 'r') as db_obj:
+    data = json.load(db_obj, object_pairs_hook=OrderedDict)
+
+has_errors = False
+
+
+def test_empty_space(icon_name):
+    """Test if an icon name has an empty space on it."""
+    global has_errors
+    if " " in icon_name:
+        has_errors = True
+        error("{} contains an empty space on it".format(icon_name))
+
+
+for key, value in data.items():
+    if value.get("linux"):
+        icon = data[key]["linux"]
+        test_empty_space(icon["root"])
+        if icon.get("symlinks"):
+            symlinks = icon["symlinks"]
+            for symlink in symlinks:
+                test_empty_space(symlink)
+exit(int(has_errors))


### PR DESCRIPTION
Recently, one of the merged commits caused an error with icon cache. It doesn't work if the icon contains a space on it. 

In order to avoid this in the future, this test should make sure that the data.json file is correct.
