### PR TITLE
Remove "idle" symlink

### DIFF
--- a/data.json
+++ b/data.json
@@ -12294,10 +12294,7 @@
     },
     "python-idle": {
         "linux": {
-            "root": "python-idle",
-            "symlinks": [
-                "idle"
-            ]
+            "root": "python-idle"
         }
     },
     "pytrainer": {


### PR DESCRIPTION
Fixes https://github.com/numixproject/numix-icon-theme-circle/issues/79. As I commented over there I don't deem it very prudent to name a  tray status icon just ``idle``. An app icon with this name though is by no means appropriate and I think we should remove it for the same reasons we don't add ``code``.

AFAIK the IDLE icon is still hardcoded anyway.
