### PR TITLE
Remove duplicate sweeper symlink

### DIFF
--- a/data.json
+++ b/data.json
@@ -6534,8 +6534,7 @@
             "symlinks": [
                 "gnomine",
                 "kmines",
-                "sgt-mines",
-                "sweeper"
+                "sgt-mines"
             ]
         }
     },


### PR DESCRIPTION
It's symlinked to ``gcleaner`` as well which makes more sense assuming we are talking about KDE Sweeper