### PR TITLE
Icon for ckb-next

### DIFF
--- a/data.json
+++ b/data.json
@@ -3253,6 +3253,7 @@
         "linux": {
             "root": "ckb",
             "symlinks": [
+                "ckb-next",
                 "polychromatic"
             ]
         }


### PR DESCRIPTION
The project [ckb](https://github.com/ccMSC/ckb) is no longer maintained, and is now developed as [ckb-next](https://github.com/ckb-next/ckb-next). This PR adds ckb-next as a symbolic link so that the icon will work with the ckb icon.