### PR TITLE
Add waterfox-icon symlink.

### DIFF
--- a/data.json
+++ b/data.json
@@ -17077,7 +17077,10 @@
     },
     "waterfox": {
         "linux": {
-            "root": "waterfox"
+            "root": "waterfox",
+            "symlinks": [
+                "waterfox-icon"
+            ]
         }
     },
     "wavebox": {


### PR DESCRIPTION
Waterfox is packaged in Arch User Repo to use `waterfox-icon.svg`.
