### PR TITLE
Fix Discord PTB icon.

### DIFF
--- a/data.json
+++ b/data.json
@@ -3931,6 +3931,7 @@
             "root": "discord",
             "symlinks": [
                 "com.discordapp.Discord",
+                "discord-ptb",
                 "web-discord"
             ]
         }


### PR DESCRIPTION
Discord PTB doesn't use a special icon unlike canary. A lot of
distributions pack their launchers with the "discord-ptb" icon
string instead of just "discord". Add a symlink to resolve the
issue.