### PR TITLE
code is also used to start MS VScode eg. under Ubuntu 16.04, so symli…

### DIFF
--- a/data.json
+++ b/data.json
@@ -15992,7 +15992,6 @@
                 "1E64_notepad.0",
                 "accessories-text-editor",
                 "blogilo",
-                "code",
                 "gedit",
                 "gedit-icon",
                 "gedit-logo",
@@ -17012,7 +17011,8 @@
                 "visual-studio-code",
                 "vsc",
                 "vscode",
-                "vso"
+                "vso",
+                "code"
             ]
         }
     },


### PR DESCRIPTION
code is also used to start MS VScode eg. under Ubuntu 16.04, so symlink "code" has been removed from "text-editor" in favor of "visualstudiocode"