### PR TITLE
fix the ubuntu vscode icon display

### DIFF
--- a/data.json
+++ b/data.json
@@ -16800,7 +16800,6 @@
                 "accessories-text-editor",
                 "blogilo",
                 "bottles_notepad",
-                "code",
                 "gedit",
                 "gedit-icon",
                 "gedit-logo",
@@ -17848,7 +17847,8 @@
                 "vsc",
                 "vscode",
                 "vscodium",
-                "vso"
+                "vso",
+                "code"
             ]
         }
     },


### PR DESCRIPTION
| Original icon | Circle icon | Square icon |
| --- | :-- | :-- |
|  ![original](https://github.com/numixproject/numix-core/blob/master/icons/circle/48/text-editor.svg) |  ![circle](https://github.com/numixproject/numix-core/blob/master/icons/circle/48/visualstudiocode.svg) | ![square](https://github.com/numixproject/numix-core/blob/master/icons/square/48//visualstudiocode.svg) |

Here, when I using the numix-icon-theme both in ubuntu 16.04 and ubuntu 18.04 I found the vscode is using the code.svg instead of the vscode.svg, and I know there have an application is using the code.svg, but I think it's not as popular as the vscode, so I change the data.json make the code.svg generate from visualstudiocode.svg instead of the text-editor.svg.

Here is the file vscode.desktop details in ubuntu:
```
[Desktop Entry]
Name=Visual Studio Code
Comment=Code Editing. Redefined.
GenericName=Text Editor
Exec=/usr/share/code/code --unity-launch %F
Icon=code
Type=Application
StartupNotify=true
StartupWMClass=Code
Categories=Utility;TextEditor;Development;IDE;
MimeType=text/plain;inode/directory;
Actions=new-empty-window;
Keywords=vscode;

X-Desktop-File-Install-Version=0.23

[Desktop Action new-empty-window]
Name=New Empty Window
Exec=/usr/share/code/code --new-window %F
Icon=code
```
THX~
