### PR TITLE
Symlinks for Fragments and Shortwave

### DIFF
--- a/data.json
+++ b/data.json
@@ -6154,7 +6154,8 @@
         "linux": {
             "root": "fragments",
             "symlinks": [
-                "de.haeckerfelix.Fragments"
+                "de.haeckerfelix.Fragments",
+                "org.gnome.Fragments"
             ]
         }
     },
@@ -7874,7 +7875,9 @@
         "linux": {
             "root": "gradio",
             "symlinks": [
-                "de.haeckerfelix.gradio"
+                "de.haeckerfelix.gradio",
+                "de.haeckerfelix.Shortwave",
+                "org.gnome.Shortwave"
             ]
         }
     },


### PR DESCRIPTION
https://gitlab.gnome.org/World/Shortwave
Shortwave is the successor of gradio
