### PR TITLE
Added circle and square app icons of Lollypop

### DIFF
--- a/icons/circle/48/numix-org.gnome.lollypop.svg
+++ b/icons/circle/48/numix-org.gnome.lollypop.svg
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="numix-org.gnome.Lollypop-circle.svg">
+  <metadata
+     id="metadata59">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     id="namedview57"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="16.879745"
+     inkscape:cy="42.994427"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:snap-others="false"
+     inkscape:snap-nodes="false"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3389" />
+    <sodipodi:guide
+       position="50.071999,24.085825"
+       orientation="0,1"
+       id="guide1289"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         style="stop-color:#344e8e;stop-opacity:1"
+         id="stop7" />
+      <stop
+         offset="1"
+         style="stop-color:#3a569c;stop-opacity:1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-642319694">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-656603142">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764-8"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-45,-57.997785)"
+       y1="0"
+       y2="0"
+       spreadMethod="pad">
+      <stop
+         stop-color="#e5e5e5"
+         stop-opacity="1"
+         id="stop2"
+         style="stop-color:#fffbf1;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#efefef"
+         stop-opacity="1"
+         id="stop4"
+         style="stop-color:#fffffe;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764-0"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-250.16949,-70.641854)">
+      <stop
+         stop-color="#e5e5e5"
+         stop-opacity="1"
+         id="stop2-6" />
+      <stop
+         offset="1"
+         stop-color="#efefef"
+         stop-opacity="1"
+         id="stop4-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764-8-3"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.000004,-0.997785)"
+       xlink:href="#linearGradient3764-0-3">
+      <stop
+         stop-color="#e5e5e5"
+         stop-opacity="1"
+         id="stop2-67"
+         style="stop-color:#fffbf1;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#efefef"
+         stop-opacity="1"
+         id="stop4-5"
+         style="stop-color:#fffffe;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764-0-3"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-250.16949,-70.641854)">
+      <stop
+         stop-color="#e5e5e5"
+         stop-opacity="1"
+         id="stop2-6-5" />
+      <stop
+         offset="1"
+         stop-color="#efefef"
+         stop-opacity="1"
+         id="stop4-2-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3764-8"
+       id="linearGradient959"
+       x1="1"
+       y1="24"
+       x2="47"
+       y2="24"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask971">
+      <g
+         transform="rotate(-90,42.09322,-57.855932)"
+         style="fill:#ffffff;fill-opacity:1"
+         id="g975">
+        <path
+           inkscape:connector-curvature="0"
+           id="path973"
+           style="fill:#ffffff;fill-opacity:1"
+           d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z" />
+      </g>
+    </mask>
+    <mask
+       maskUnits="userSpaceOnUse"
+       id="mask971-6">
+      <g
+         transform="rotate(-90,42.09322,-57.855932)"
+         style="fill:#ffffff;fill-opacity:1"
+         id="g975-0">
+        <path
+           inkscape:connector-curvature="0"
+           id="path973-6"
+           style="fill:#ffffff;fill-opacity:1"
+           d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z" />
+      </g>
+    </mask>
+    <linearGradient
+       id="linearGradient3764-8-3-8"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(51.000004,-0.997785)"
+       xlink:href="#linearGradient3764-0-3-3">
+      <stop
+         stop-color="#e5e5e5"
+         stop-opacity="1"
+         id="stop2-67-9"
+         style="stop-color:#fffbf1;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#efefef"
+         stop-opacity="1"
+         id="stop4-5-7"
+         style="stop-color:#fffffe;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764-0-3-3"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-250.16949,-70.641854)">
+      <stop
+         stop-color="#e5e5e5"
+         stop-opacity="1"
+         id="stop2-6-5-6" />
+      <stop
+         offset="1"
+         stop-color="#efefef"
+         stop-opacity="1"
+         id="stop4-2-6-1" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1296">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1298"
+         style="fill:#ffffff;fill-opacity:1"
+         d="M 1,24 C 1,11.297 11.297,1 24,1 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 Z" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3764-8-3-0"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1.000004,-0.997785)"
+       xlink:href="#linearGradient3764-0-3-2">
+      <stop
+         stop-color="#e5e5e5"
+         stop-opacity="1"
+         id="stop2-67-6"
+         style="stop-color:#fffbf1;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#efefef"
+         stop-opacity="1"
+         id="stop4-5-3"
+         style="stop-color:#fffffe;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764-0-3-2"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-250.16949,-70.641854)">
+      <stop
+         stop-color="#e5e5e5"
+         stop-opacity="1"
+         id="stop2-6-5-0" />
+      <stop
+         offset="1"
+         stop-color="#efefef"
+         stop-opacity="1"
+         id="stop4-2-6-6" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1364">
+      <rect
+         id="rect1366"
+         transform="rotate(-90)"
+         rx="4"
+         y="1"
+         x="-47"
+         height="46"
+         width="46"
+         style="fill:#ffffff;fill-opacity:1" />
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       style="opacity:0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       style="opacity:0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       style="opacity:0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29"
+     style="fill:url(#linearGradient959);fill-opacity:1.0"
+     transform="matrix(0,-1,1,0,0,48)">
+    <path
+       d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z"
+       style="fill:url(#linearGradient959);fill-opacity:1.0"
+       id="path31"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     style="fill:#e64f80;fill-opacity:1;stroke:none;stroke-width:0.30653918px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22.559359,-12.471801 c -1.740892,0.07393 -3.474248,0.272512 -5.186751,0.594229 -0.287755,0.42143 -0.564989,0.849948 -0.831444,1.285158 -3.518297,6.0684598 -4.859005,13.1563581 -3.800226,20.0905924 3.080662,-2.385839 6.840115,-3.7304038 10.73509,-3.8393947 0.873275,-3.1804549 2.149604,-6.23620609 3.797946,-9.09293 1.693547,-2.875675 3.752011,-5.5201685 6.124141,-7.8676367 -3.533902,-0.930797 -7.187624,-1.325207 -10.838756,-1.170018 z M -1.7990003,-1.8725963 C -5.6244894,1.9548602 -8.5503667,6.5855992 -10.364511,11.6839 c 0.219759,0.460165 0.4509157,0.9148 0.6932568,1.363483 3.4725732,6.09518 8.92239865,10.821826 15.4473949,13.39756 C 5.2652331,22.581685 5.9959958,18.656037 7.8628077,15.235393 5.5537027,12.880086 3.5552345,10.239192 1.9160177,7.3769546 0.28407062,4.466836 -0.96462711,1.3578623 -1.7990003,-1.8725963 Z M 50.202079,0.20025358 C 43.187086,0.20356928 36.383535,2.6022432 30.917585,6.999234 c 3.609353,1.4667186 6.658981,4.042896 8.708303,7.356349 3.189556,-0.841675 6.473652,-1.272022 9.772381,-1.28057 3.336324,0.02145 6.655863,0.474332 9.876009,1.34736 C 57.840163,9.2041169 55.262802,4.3703859 51.729068,0.27165358 51.22074,0.23525332 50.711587,0.21147933 50.202079,0.20035358 Z M 17.473746,12.569265 c -0.801821,-0.0882 -1.464833,0.48377 -1.464833,1.71817 0,0 0.05863,16.75228 0,19.27987 0.05863,2.11613 1.294494,2.23358 2.528887,1.46943 1.23441,-0.76416 15.107428,-8.6395 16.753287,-9.63878 1.64589,-0.99929 0.821952,-2.35105 -0.177335,-2.93886 -0.999272,-0.5878 -15.694025,-8.87582 -16.810873,-9.5812 -0.279201,-0.17634 -0.56186,-0.27923 -0.829133,-0.30863 z m 24.750132,9.048218 c 0.510901,3.86326 -0.21987,7.788909 -2.08669,11.20955 2.309112,2.355306 4.307587,4.9962 5.94681,7.85844 1.631948,2.910118 2.880647,6.019092 3.715021,9.24955 3.825481,-3.827457 6.751351,-8.458193 8.56549,-13.55649 -0.219754,-0.460164 -0.450905,-0.914798 -0.693241,-1.36348 -3.47257,-6.095183 -8.922394,-10.821832 -15.44739,-13.39757 z m -53.498156,12.02258 c 1.4341168,5.218249 4.0114771,10.051973 7.5452077,14.1507 0.5083343,0.03643 1.0174949,0.06024 1.527011,0.0714 7.0149889,-0.0033 13.8185373,-2.401985 19.2844863,-6.79897 -3.609356,-1.466711 -6.658991,-4.042881 -8.7083203,-7.35633 -3.1895505,0.841667 -6.4736387,1.272007 -9.77236,1.28055 -3.3363291,-0.02145 -6.6558729,-0.474324 -9.8760247,-1.34735 z m 46.533337,4.92418 c -3.080662,2.385841 -6.840115,3.730408 -10.735091,3.8394 -0.87327,3.180451 -2.149595,6.236198 -3.79793,9.09292 -1.692829,2.875545 -3.750512,5.520037 -6.121829,7.86765 5.232237,1.378042 10.705527,1.574724 16.02318,0.57579 0.28775,-0.421434 0.564978,-0.849956 0.831428,-1.28517 3.518302,-6.068457 4.859015,-13.156355 3.800242,-20.09059 z"
+     id="path3682-7-0-22-9-0"
+     inkscape:connector-curvature="0"
+     mask="none"
+     sodipodi:nodetypes="cccccccccccccccccccccccsccscscsccccccccccccccccccccc"
+     clip-path="url(#clipPath1296)" />
+  <g
+     id="g53">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       style="opacity:0.1"
+       id="path55" />
+  </g>
+  <circle
+     style="opacity:0.9;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3391"
+     cx="24"
+     cy="24"
+     r="15" />
+  <rect
+     style="opacity:0.406;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3387"
+     width="24"
+     height="24"
+     x="12.20339"
+     y="12.101695" />
+  <rect
+     id="rect27-2"
+     transform="rotate(-90)"
+     rx="4"
+     y="1.6538922e-15"
+     x="2"
+     height="46"
+     width="46"
+     style="fill:url(#linearGradient3764-8-3);fill-opacity:1" />
+  <path
+     transform="translate(-1,-49)"
+     style="fill:#e64f80;fill-opacity:1;stroke:none;stroke-width:0.30653918px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 22.559359,-12.471801 c -1.740892,0.07393 -3.474248,0.272512 -5.186751,0.594229 -0.287755,0.42143 -0.564989,0.849948 -0.831444,1.285158 -3.518297,6.0684598 -4.859005,13.1563581 -3.800226,20.0905924 3.080662,-2.385839 6.840115,-3.7304038 10.73509,-3.8393947 0.873275,-3.1804549 2.149604,-6.23620609 3.797946,-9.09293 1.693547,-2.875675 3.752011,-5.5201685 6.124141,-7.8676367 -3.533902,-0.930797 -7.187624,-1.325207 -10.838756,-1.170018 z M -1.7990003,-1.8725963 C -5.6244894,1.9548602 -8.5503667,6.5855992 -10.364511,11.6839 c 0.219759,0.460165 0.4509157,0.9148 0.6932568,1.363483 3.4725732,6.09518 8.92239865,10.821826 15.4473949,13.39756 C 5.2652331,22.581685 5.9959958,18.656037 7.8628077,15.235393 5.5537027,12.880086 3.5552345,10.239192 1.9160177,7.3769546 0.28407062,4.466836 -0.96462711,1.3578623 -1.7990003,-1.8725963 Z M 50.202079,0.20025358 C 43.187086,0.20356928 36.383535,2.6022432 30.917585,6.999234 c 3.609353,1.4667186 6.658981,4.042896 8.708303,7.356349 3.189556,-0.841675 6.473652,-1.272022 9.772381,-1.28057 3.336324,0.02145 6.655863,0.474332 9.876009,1.34736 C 57.840163,9.2041169 55.262802,4.3703859 51.729068,0.27165358 51.22074,0.23525332 50.711587,0.21147933 50.202079,0.20035358 Z M 17.473746,12.569265 c -0.801821,-0.0882 -1.464833,0.48377 -1.464833,1.71817 0,0 0.05863,16.75228 0,19.27987 0.05863,2.11613 1.294494,2.23358 2.528887,1.46943 1.23441,-0.76416 15.107428,-8.6395 16.753287,-9.63878 1.64589,-0.99929 0.821952,-2.35105 -0.177335,-2.93886 -0.999272,-0.5878 -15.694025,-8.87582 -16.810873,-9.5812 -0.279201,-0.17634 -0.56186,-0.27923 -0.829133,-0.30863 z m 24.750132,9.048218 c 0.510901,3.86326 -0.21987,7.788909 -2.08669,11.20955 2.309112,2.355306 4.307587,4.9962 5.94681,7.85844 1.631948,2.910118 2.880647,6.019092 3.715021,9.24955 3.825481,-3.827457 6.751351,-8.458193 8.56549,-13.55649 -0.219754,-0.460164 -0.450905,-0.914798 -0.693241,-1.36348 -3.47257,-6.095183 -8.922394,-10.821832 -15.44739,-13.39757 z m -53.498156,12.02258 c 1.4341168,5.218249 4.0114771,10.051973 7.5452077,14.1507 0.5083343,0.03643 1.0174949,0.06024 1.527011,0.0714 7.0149889,-0.0033 13.8185373,-2.401985 19.2844863,-6.79897 -3.609356,-1.466711 -6.658991,-4.042881 -8.7083203,-7.35633 -3.1895505,0.841667 -6.4736387,1.272007 -9.77236,1.28055 -3.3363291,-0.02145 -6.6558729,-0.474324 -9.8760247,-1.34735 z m 46.533337,4.92418 c -3.080662,2.385841 -6.840115,3.730408 -10.735091,3.8394 -0.87327,3.180451 -2.149595,6.236198 -3.79793,9.09292 -1.692829,2.875545 -3.750512,5.520037 -6.121829,7.86765 5.232237,1.378042 10.705527,1.574724 16.02318,0.57579 0.28775,-0.421434 0.564978,-0.849956 0.831428,-1.28517 3.518302,-6.068457 4.859015,-13.156355 3.800242,-20.09059 z"
+     id="path3682-7-0-22-9-0-1"
+     inkscape:connector-curvature="0"
+     mask="none"
+     sodipodi:nodetypes="cccccccccccccccccccccccsccscscsccccccccccccccccccccc"
+     clip-path="url(#clipPath1364)" />
+  <g
+     transform="translate(-1,-49.000003)"
+     id="g79">
+    <g
+       transform="translate(0,-1004.3622)"
+       id="g77">
+      <path
+         style="opacity:0.1"
+         inkscape:connector-curvature="0"
+         d="m 1,1043.36 v 4 c 0,2.216 1.784,4 4,4 h 38 c 2.216,0 4,-1.784 4,-4 v -4 c 0,2.216 -1.784,4 -4,4 H 5 c -2.216,0 -4,-1.784 -4,-4 z"
+         id="path75" />
+    </g>
+  </g>
+  <path
+     style="fill:#e64f80;fill-opacity:1;stroke:none;stroke-width:0.30653918px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 141.55936,-43.2888 a 36.473259,36.473259 0 0 0 -5.18675,0.59423 30.789851,30.789851 0 0 0 -0.83145,1.28516 30.789851,30.789851 0 0 0 -3.80022,20.09059 18.371569,18.371569 0 0 1 10.73509,-3.83939 38.693421,38.693421 0 0 1 3.79794,-9.09293 38.693421,38.693421 0 0 1 6.12414,-7.86764 36.473259,36.473259 0 0 0 -10.83875,-1.17002 z M 117.201,-32.68959 a 36.473259,36.473259 0 0 0 -8.56551,13.55649 30.789851,30.789851 0 0 0 0.69326,1.363483 30.789851,30.789851 0 0 0 15.44739,13.3975601 18.371569,18.371569 0 0 1 2.08667,-11.2095501 38.693421,38.693421 0 0 1 -5.94679,-7.858433 38.693421,38.693421 0 0 1 -3.71502,-9.24955 z m 52.00108,2.07285 a 30.789851,30.789851 0 0 0 -19.2845,6.79898 18.371569,18.371569 0 0 1 8.70831,7.356343 38.69342,38.69342 0 0 1 9.77238,-1.28057 38.69342,38.69342 0 0 1 9.87601,1.34736 36.473259,36.473259 0 0 0 -7.54521,-14.150713 30.789851,30.789851 0 0 0 -1.52699,-0.0713 z m -32.72812,12.969183 c -0.80182,-0.0882 -1.46483,0.48377 -1.46483,1.71817 0,0 0.0586,16.75228009 0,19.2798701 0.0586,2.11613 1.29449,2.23358 2.52889,1.46943 1.23441,-0.76416 15.10742,-8.6395 16.75328,-9.63878 1.64589,-0.99929 0.82195,-2.35105 -0.17733,-2.93886 -0.99927,-0.5878 -15.69403,-8.8758201 -16.81088,-9.5812001 -0.2792,-0.17634 -0.56186,-0.27923 -0.82913,-0.30863 z m 24.74992,8.4480401 a 18.371569,18.371569 0 0 1 -2.08669,11.20955 38.693421,38.693421 0 0 1 5.94681,7.85844 38.693421,38.693421 0 0 1 3.71502,9.2495499 36.473259,36.473259 0 0 0 8.56549,-13.5564899 30.789851,30.789851 0 0 0 -0.69324,-1.36348 30.789851,30.789851 0 0 0 -15.44739,-13.39757 z m -53.49816,12.02258 a 36.473259,36.473259 0 0 0 7.54521,14.1506999 30.789851,30.789851 0 0 0 1.52701,0.0714 30.789851,30.789851 0 0 0 19.28449,-6.79897 18.371569,18.371569 0 0 1 -8.70832,-7.3563299 38.69342,38.69342 0 0 1 -9.77236,1.28055 38.69342,38.69342 0 0 1 -9.87603,-1.34735 z m 46.53334,4.92418 a 18.371569,18.371569 0 0 1 -10.73509,3.8393999 38.693421,38.693421 0 0 1 -3.79793,9.09292 38.693421,38.693421 0 0 1 -6.12183,7.86765 36.473259,36.473259 0 0 0 16.02318,0.57579 30.789851,30.789851 0 0 0 0.83143,-1.28517 30.789851,30.789851 0 0 0 3.80024,-20.0905899 z"
+     id="path3682-7-0-22-9"
+     inkscape:connector-curvature="0"
+     mask="none" />
+</svg>


### PR DESCRIPTION
This pull request isn't actually useful in the icon that it creates, but I wanted to close the loop of this long ago fork adding an icon which still isn't symlinked in Core (lollypop with the lower case `l`).