### PR TITLE
Symlink for PhotoFlare

### DIFF
--- a/data.json
+++ b/data.json
@@ -13349,7 +13349,9 @@
         "linux": {
             "root": "photofiltrelx",
             "symlinks": [
-                "PhotoFiltre-LX"
+                "io.photoflare.photoflare",
+                "PhotoFiltre-LX",
+                "photoflare"
             ]
         }
     },


### PR DESCRIPTION
https://github.com/PhotoFlare/photoflare

PhotoFiltre LX got renamed, it appears.
