### PR TITLE
Symlink for Celluloid

### DIFF
--- a/data.json
+++ b/data.json
@@ -11702,6 +11702,7 @@
             "root": "mpv",
             "symlinks": [
                 "gnome-mpv",
+                "io.github.Celluloid",
                 "io.github.GnomeMpv",
                 "kplayer",
                 "mpv-icon-8bit-64x64"


### PR DESCRIPTION
which GNOME MPV got renamed to.
https://github.com/celluloid-player/celluloid
