### PR TITLE
Symlink for Cast to TV

### DIFF
--- a/data.json
+++ b/data.json
@@ -11553,6 +11553,7 @@
         "linux": {
             "root": "mkchromecast",
             "symlinks": [
+                "cast-to-tv",
                 "gnomecast"
             ]
         }


### PR DESCRIPTION
Can symlink for [gnome-shell-extension-cast-to-tv](https://github.com/Rafostar/gnome-shell-extension-cast-to-tv) be added?