### PR TITLE
Icons for Alacritty

### DIFF
--- a/data.json
+++ b/data.json
@@ -550,6 +550,14 @@
             ]
         }
     },
+    "alacritty": {
+        "linux": {
+            "root": "alacritty",
+            "symlinks": [
+                "Alacritty"
+            ]
+        }
+    },
     "albert": {
         "linux": {
             "root": "albert"

--- a/icons/circle/48/alacritty.svg
+++ b/icons/circle/48/alacritty.svg
@@ -1,0 +1,17 @@
+<svg version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <linearGradient id="bg" x2="0" y1="1" y2="47" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#213a47" offset="0"/>
+   <stop style="stop-color:#1b2f39" offset="1"/>
+  </linearGradient>
+ </defs>
+ <path d="m36.31 5c5.859 4.062 9.688 10.831 9.688 18.5 0 12.426-10.07 22.5-22.5 22.5-7.669 0-14.438-3.828-18.5-9.688 1.037 1.822 2.306 3.499 3.781 4.969 4.085 3.712 9.514 5.969 15.469 5.969 12.703 0 23-10.298 23-23 0-5.954-2.256-11.384-5.969-15.469-1.469-1.475-3.147-2.744-4.969-3.781zm4.969 3.781c3.854 4.113 6.219 9.637 6.219 15.719 0 12.703-10.297 23-23 23-6.081 0-11.606-2.364-15.719-6.219 4.16 4.144 9.883 6.719 16.219 6.719 12.703 0 23-10.298 23-23 0-6.335-2.575-12.06-6.719-16.219z" style="opacity:.05"/>
+ <path d="m41.28 8.781c3.712 4.085 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.113 3.854 9.637 6.219 15.719 6.219 12.703 0 23-10.298 23-23 0-6.081-2.364-11.606-6.219-15.719z" style="opacity:.1"/>
+ <path d="m31.25 2.375c8.615 3.154 14.75 11.417 14.75 21.13 0 12.426-10.07 22.5-22.5 22.5-9.708 0-17.971-6.135-21.12-14.75a23 23 0 0 0 44.875-7 23 23 0 0 0-16-21.875z" style="opacity:.2"/>
+ <circle cx="24" cy="24" r="23" style="fill:url(#bg)"/>
+ <path d="m40.03 7.531c3.712 4.084 5.969 9.514 5.969 15.469 0 12.703-10.297 23-23 23-5.954 0-11.384-2.256-15.469-5.969 4.178 4.291 10.01 6.969 16.469 6.969 12.703 0 23-10.298 23-23 0-6.462-2.677-12.291-6.969-16.469z" style="opacity:.1"/>
+ <path d="m23 12-9 23h4l7-17 7 17h4l-9-23zm2 10-3 7 3 9 3-9z" style="clip-rule:evenodd;enable-background:new;fill-rule:evenodd;opacity:.1;paint-order:normal"/>
+ <path d="m21.932 25.828-0.93164 2.1719 3 9 3-9-0.93164-2.1719z" style="clip-rule:evenodd;enable-background:new;fill-rule:evenodd;fill:#1fa3f7;paint-order:normal"/>
+ <path d="m22 11-9 23h4l7-17 7 17h4l-9-23z" style="clip-rule:evenodd;enable-background:new;fill-rule:evenodd;fill:#f8901b;paint-order:normal"/>
+ <path d="m24 21-2.0684 4.8281 2.0684 5.1719 2.0684-5.1719z" style="clip-rule:evenodd;enable-background:new;fill-rule:evenodd;fill:#c0e5fb;paint-order:normal"/>
+</svg>

--- a/icons/square/48/alacritty.svg
+++ b/icons/square/48/alacritty.svg
@@ -1,0 +1,17 @@
+<svg version="1.1" viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg">
+ <defs>
+  <linearGradient id="bg" x2="0" y1="1" y2="47" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#213a47" offset="0"/>
+   <stop style="stop-color:#1b2f39" offset="1"/>
+  </linearGradient>
+ </defs>
+ <path d="m1 43v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4zm0 0.5v0.5c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.5c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.02"/>
+ <path d="m1 43.25v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.05"/>
+ <path d="m1 43v0.25c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-0.25c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.1"/>
+ <rect x="1" y="1" width="46" height="46" rx="4" style="fill:url(#bg)"/>
+ <path d="m1 39v4c0 2.216 1.784 4 4 4h38c2.216 0 4-1.784 4-4v-4c0 2.216-1.784 4-4 4h-38c-2.216 0-4-1.784-4-4z" style="opacity:.1"/>
+ <path d="m22 11-9 23h4l7-17 7 17h4l-9-23zm2 10-3 7 3 9 3-9z" style="clip-rule:evenodd;enable-background:new;fill-rule:evenodd;opacity:.1;paint-order:normal"/>
+ <path d="m21.932 24.828-0.93164 2.1719 3 9 3-9-0.93164-2.1719z" style="clip-rule:evenodd;enable-background:new;fill-rule:evenodd;fill:#1fa3f7;paint-order:normal"/>
+ <path d="m22 10-9 23h4l7-17 7 17h4l-9-23z" style="clip-rule:evenodd;enable-background:new;fill-rule:evenodd;fill:#f8901b;paint-order:normal"/>
+ <path d="m24 20-2.0684 4.8281 2.0684 5.1719 2.0684-5.1719z" style="clip-rule:evenodd;enable-background:new;fill-rule:evenodd;fill:#c0e5fb;paint-order:normal"/>
+</svg>


### PR DESCRIPTION
Fixes #4859

![Alacritty](https://user-images.githubusercontent.com/7050624/57159468-4475fe80-6de6-11e9-8153-b1028681bad7.png)
![Alacritty-ci](https://user-images.githubusercontent.com/7050624/57159470-450e9500-6de6-11e9-8755-c18882b3126c.png)
![Alacritty-sq](https://user-images.githubusercontent.com/7050624/57159471-450e9500-6de6-11e9-8c3a-e87350227f40.png)

Maybe a darker orange or rather this? Doesn't seem to scale as well, same for other fine scanline designs.
![Alacritty-alt](https://user-images.githubusercontent.com/7050624/57159503-5a83bf00-6de6-11e9-8e2d-2d1a84b4193b.png)
