### PR TITLE
Symlinks for Tau

### DIFF
--- a/data.json
+++ b/data.json
@@ -8658,7 +8658,9 @@
         "linux": {
             "root": "gxi",
             "symlinks": [
-                "com.github.Cogitri.gxi"
+                "com.github.Cogitri.gxi",
+                "org.gnome.Tau",
+                "tau"
             ]
         }
     },


### PR DESCRIPTION
gxi got renamed.
https://gitlab.gnome.org/World/Tau|
