### PR TITLE
Symlink for lpub3d

### DIFF
--- a/data.json
+++ b/data.json
@@ -11549,7 +11549,11 @@
     },
     "lpub": {
         "linux": {
-            "root": "lpub"
+            "root": "lpub",
+            "symlinks": [
+                "lpub3d",
+                "org.trevorsandy.lpub3d"
+            ]
         }
     },
     "lshw": {


### PR DESCRIPTION
Actively maintained alternative to lpub 
https://github.com/trevorsandy/lpub3d