### PR TITLE
Add symlink for Zoom icon

### DIFF
--- a/data.json
+++ b/data.json
@@ -24517,7 +24517,8 @@
             "symlinks": [
                 "us.zoom.Zoom",
                 "zoom-desktop",
-                "zoom-icon"
+                "zoom-icon",
+                "zoom-videocam"
             ]
         }
     },


### PR DESCRIPTION
This is Gentoo-specific thing. Line 81 of [this file](https://gitweb.gentoo.org/repo/gentoo.git/tree/net-im/zoom/zoom-5.3.469451.0927.ebuild#n81).