### PR TITLE
Fix quotation marks

### DIFF
--- a/data.json
+++ b/data.json
@@ -9531,7 +9531,7 @@
             "symlinks": [
                 "aptik-battery-monitor",
                 "mate-power-statistics",
-                "nl.brixit.powersupply,
+                "nl.brixit.powersupply",
                 "org.gnome.PowerStats",
                 "preferences-system-power-management"
             ]


### PR DESCRIPTION
`./gen.py --theme circle --platform linux`
```
Traceback (most recent call last):
  File "/var/tmp/portage/x11-themes/numix-icon-theme-9999/work/numix-core/./gen.py", line 38, in <module>
    icons = load(data)
  File "/usr/lib/python3.9/json/__init__.py", line 293, in load
    return loads(fp.read(),
  File "/usr/lib/python3.9/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.9/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.9/json/decoder.py", line 353, in raw_decode
    obj, end = self.scan_once(s, idx)
json.decoder.JSONDecodeError: Invalid control character at: line 9534 column 40 (char 213701)
```