### PR TITLE
Add symlink for MuseScore3

### DIFF
--- a/data.json
+++ b/data.json
@@ -17762,6 +17762,7 @@
             "root": "musescore",
             "symlinks": [
                 "mscore",
+                "mscore3",
                 "Musescore",
                 "org.musescore.MuseScore"
             ]


### PR DESCRIPTION
MuseScore3 has a different icon name.