### PR TITLE
update python to 3.11 in test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.11
 
       - name: Install dependencies
         run: pip3 install flake8
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.11
 
       - name: Install dependencies
         run: pip3 install jsonschema


### PR DESCRIPTION
Sets python version to ``3.11`` for the GitHub actions tests.
Fixes #5821
