### PR TITLE
fix data.json

### DIFF
--- a/data.json
+++ b/data.json
@@ -924,7 +924,7 @@
             "symlinks": [
                 "com.github.alainm23.planner",
                 "com.github.dahenson.agenda",
-                "io.github.alainm23.planify",
+                "io.github.alainm23.planify"
             ]
         }
     },


### PR DESCRIPTION
currently results on arch-linux in:

```
  ==> Starting prepare()...
   Traceback (most recent call last):
   File "/home/somerandomnoobontheInternet/.cache/paru/clone/numix-icon-theme-  pack/src/numix-core/./gen.py", line 35, in <module>
     icons = load(data)
             ^^^^^^^^^^
   File "/usr/lib/python3.11/json/__init__.py", line 293, in load
return loads(fp.read(),
            ^^^^^^^^^^^^^^^^
   File "/usr/lib/python3.11/json/__init__.py", line 346, in loads
     return _default_decoder.decode(s)
       ^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3.11/json/decoder.py", line 337, in decode
obj, end = self.raw_decode(s, idx=_w(s, 0).end())
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3.11/json/decoder.py", line 355, in raw_decode
raise JSONDecodeError("Expecting value", s, err.value) from None
 json.decoder.JSONDecodeError: Expecting value: line 928 column 13 (char 24984)
 ==> ERROR: A failure occurred in prepare().
     Aborting...
 error: failed to build 'numix-icon-theme-pack-r6086-1 (numix-icon-theme-pack-git)':
 error: packages failed to build: numix-icon-theme-pack-r6086-1 (numix-icon-theme-pack-git)
```
