### PR TITLE
Add com.mtkennerly.ludusavi alias for Ludusavi

### DIFF
--- a/data.json
+++ b/data.json
@@ -19049,7 +19049,8 @@
         "linux": {
             "root": "ludusavi",
             "symlinks": [
-                "com.github.mtkennerly.ludusavi"
+                "com.github.mtkennerly.ludusavi",
+                "com.mtkennerly.ludusavi"
             ]
         }
     },


### PR DESCRIPTION
The next Ludusavi release (v0.27.0) will report its app ID as `com.mtkennerly.ludusavi` instead of just `ludusavi` to be more conformant. Note that this is intentionally different from the Flatpak ID (`com.github.mtkennerly.ludusavi`), which I think is too late to change now.

More context:

* https://github.com/mtkennerly/ludusavi/pull/417
* https://github.com/mtkennerly/ludusavi/commit/0625c60b5ddc348bed8f12edea7ca17160056a51
