### PR TITLE
Removed @Foggalong from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,11 @@
 # https://help.github.com/articles/about-codeowners
 
 # General Owners
-*           @Foggalong @palob
+*           @palob
 
 # Icon Owners
-/icons/     @Foggalong @palob
-/templates/ @Foggalong @palob
+/icons/     @palob
+/templates/ @palob
 
 # Python Owners
-*.py        @Foggalong @bil-elmoussaoui
+*.py        @bil-elmoussaoui


### PR DESCRIPTION
While checking my "outstanding reviews" I noticed I was still listed as a code owner for this project, this PR just removes me from the list.