### PR TITLE
Symlink "scantailor-universal" → "scantailor"

### DIFF
--- a/data.json
+++ b/data.json
@@ -28811,7 +28811,8 @@
             "symlinks": [
                 "com.github._4lex4.ScanTailor-Advanced",
                 "org.scantailor.ScanTailor",
-                "ScanTailor"
+                "ScanTailor",
+                "scantailor-universal"
             ]
         }
     },


### PR DESCRIPTION
[github.com/trufanov-nok/scantailor-universal](https://github.com/trufanov-nok/scantailor-universal)
[.desktop file](https://github.com/trufanov-nok/scantailor-universal/blob/77b06d3b2049c9419e2e863ba68d4f3bcfa2ceed/debian/scantailor-universal.desktop#L6)



